### PR TITLE
Ellipses in pagination nav should only appear when there are pages between the current page and the first or last page

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1484,8 +1484,12 @@ main.ebooks nav ol li.highlighted::after{
 
 article nav ol li.highlighted:first-child::before,
 article nav ol li.highlighted:last-child::after,
+article nav ol li.highlighted:nth-child(2)::before,
+article nav ol li.highlighted:nth-last-child(2)::after,
 main.ebooks nav ol li.highlighted:first-child::before,
-main.ebooks nav ol li.highlighted:last-child::after{
+main.ebooks nav ol li.highlighted:last-child::after,
+main.ebooks nav ol li.highlighted:nth-child(2)::before,
+main.ebooks nav ol li.highlighted:nth-last-child(2)::after{
 	display: none;
 }
 


### PR DESCRIPTION
Currently, an ellipses appears in the pagination nav at the bottom of the page before and after the currently highlighted page, to indicate that the list is truncated. It looks like this right now:
![SE_css_bad](https://user-images.githubusercontent.com/5344804/54412408-bc119200-46af-11e9-95b9-2da025c47919.png)

However, if the user is on page 2, the ellipses is still present, despite no pages existing between the current page and the first. My PR will fix this.
![SE_css_nav](https://user-images.githubusercontent.com/5344804/54412497-2aeeeb00-46b0-11e9-8c6d-91138616f4e8.png)

It will also work when there are only two pages in the current list of pages.
![SE_css_nav2](https://user-images.githubusercontent.com/5344804/54412529-4954e680-46b0-11e9-829d-670ff48f9c0e.png)

This is an exceedingly minor nitpick but its been bothering me, so I thought I'd try my hand at fixing it.