### PR TITLE
Fix vagrant provision script.

### DIFF
--- a/scripts/vagrant/provision
+++ b/scripts/vagrant/provision
@@ -12,7 +12,8 @@ set -e
 set -o pipefail
 
 # Install some pre-flight dependencies.
-sudo apt-get install -y python3-pip libxml2-utils librsvg2-bin libimage-exiftool-perl imagemagick jarwrapper default-jre inkscape calibre curl
+sudo apt-get install -y python3-pip libxml2-utils librsvg2-bin libimage-exiftool-perl imagemagick jarwrapper default-jre inkscape calibre curl\
+	firefox
 
 # Install required fonts.
 mkdir -p ~/.local/share/fonts/

--- a/scripts/vagrant/provision
+++ b/scripts/vagrant/provision
@@ -90,6 +90,8 @@ server {
 	rewrite ^/ebooks/([^\.]+?)/?$ /ebooks/ebook.php?url-path=$1;
 	rewrite ^/tags/([^\./]+?)/?$ /ebooks/index.php?tag=$1;
 	rewrite ^/collections/([^\./]+?)/?$ /ebooks/index.php?collection=$1;
+	rewrite ^/images/covers/([^\./]+?)-[0-9a-f]+-cover([^\./]+).jpg$ /images/covers/$1-cover$2.jpg;
+	rewrite ^/images/covers/([^\./]+?)-[0-9a-f]+-hero([^\./]+).jpg$ /images/covers/$1-hero$2.jpg;
 }
 EOF
 

--- a/scripts/vagrant/provision
+++ b/scripts/vagrant/provision
@@ -84,7 +84,7 @@ server {
 	}
 
 	location @extensionless-php {
-    		rewrite ^(.*)$ $1.php last;
+		rewrite ^(.*)$ $1.php last;
 	}
 
 	rewrite ^/ebooks/([^\./]+?)/$ /ebooks/author.php?url-path=$1;
@@ -93,6 +93,7 @@ server {
 	rewrite ^/collections/([^\./]+?)/?$ /ebooks/index.php?collection=$1;
 	rewrite ^/images/covers/([^\./]+?)-[0-9a-f]+-cover([^\./]+).jpg$ /images/covers/$1-cover$2.jpg;
 	rewrite ^/images/covers/([^\./]+?)-[0-9a-f]+-hero([^\./]+).jpg$ /images/covers/$1-hero$2.jpg;
+	rewrite ^/rss/new-releases/?$ /rss/new-releases.xml;
 }
 EOF
 


### PR DESCRIPTION
Some ebooks require firefox for building, and image cover urls as well as new-releases.xml need a rewrite. Perhaps those rewrites should be mentioned in the readme, too.