### PR TITLE
Reduce the size of the ebook heading and padding on mobile

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1782,6 +1782,20 @@ main.ebooks nav ol li.highlighted:nth-last-child(2)::after{
 		font-size: 1rem;
 		margin: 0;
 	}
+
+	article.ebook > header > div{
+		margin: 1rem;
+		padding: 1rem;
+		max-width: 85%;
+	}
+
+	article.ebook h1{
+		font-size: 1.5rem;
+	}
+
+	article.ebook > header > div > p{
+		font-size: 1.2rem;
+	}
 }
 
 @media(max-width: 380px){


### PR DESCRIPTION
A lot of our ebook titles are way too wide on mobile (up to 500px). This reduces the size of the text a bit, but also reduces the padding on either side to give it more room.

| Before | After |
|:-------|:------|
| ![Screenshot 2019-10-16 at 17 05 04](https://user-images.githubusercontent.com/7414/66932056-51567980-f037-11e9-94a4-16cda43af9d3.png) | ![Screenshot 2019-10-16 at 17 05 17](https://user-images.githubusercontent.com/7414/66932060-51ef1000-f037-11e9-8a4b-6205a586f552.png) |
| ![Screenshot 2019-10-16 at 17 05 55](https://user-images.githubusercontent.com/7414/66932061-51ef1000-f037-11e9-9f54-58a1e717bfdf.png) | ![Screenshot 2019-10-16 at 17 06 10](https://user-images.githubusercontent.com/7414/66932065-5287a680-f037-11e9-8806-14e25b6d895e.png) |
