### PR TITLE
Fix search field styling in Safari

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1495,7 +1495,8 @@ input[type="search"]{
 	color: var(--body-text);
 }
 
-/* remove some styles from Chromium */
+/* remove some styles from Chromium / Webkit */
+input[type="search"],
 input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button{
 	-webkit-appearance: none;


### PR DESCRIPTION
Not sure when this broke, but this disables the default search field style that has shown up. On linght mode it’s ugly but usable, but in dark mode it’s impossible to read your search terms.

Before:
![Screenshot 2019-12-01 at 13 14 54](https://user-images.githubusercontent.com/7414/69913767-89c1e380-143c-11ea-92bf-9f82d39630c1.png)

After:
![Screenshot 2019-12-01 at 13 15 23](https://user-images.githubusercontent.com/7414/69913768-89c1e380-143c-11ea-9769-aff179360c52.png)
