### PR TITLE
Refine #long-description with "authority", "meta-auth" deprecated

### DIFF
--- a/www/contribute/metadata.php
+++ b/www/contribute/metadata.php
@@ -199,9 +199,6 @@ require_once('Core.php');
 				<p>The long description must be in <em>escaped</em> HTML, with the HTML beginning on its own line after the <code class="html">&lt;meta property="se:long-description"&gt;</code> element.</p>
 				<p>An easy way to escape your HTML is to compose your long description in regular HTML, then insert it into the <code class="html">&lt;meta property="se:long-description"&gt;</code> element surrounded by a <code class="html">&lt;![CDATA[ ... ]]&gt;</code> element. Once you’re done, run the <code class="path">clean</code> tool, which will remove the <code class="html">&lt;![CDATA[ ... ]]&gt;</code> element and escape the contained HTML for you.</p>
 			</li>
-			<li>
-				<p>Include the following element directly after the long description: <code class="html">&lt;meta property="authority" refines="#long-description"&gt;https://standardebooks.org&lt;/meta&gt;</code></p>
-			</li>
 		</ul>
 		<h2>The <code class="html">&lt;dc:language&gt;</code> element</h2>
 		<p>The <code class="html">&lt;dc:language&gt;</code> element follows the long description block. It contains the IETF language tag for the language that the work is in. Usually this is either <code class="ietf">en-US</code> or <code class="ietf">en-GB</code>.</p>

--- a/www/contribute/metadata.php
+++ b/www/contribute/metadata.php
@@ -200,7 +200,7 @@ require_once('Core.php');
 				<p>An easy way to escape your HTML is to compose your long description in regular HTML, then insert it into the <code class="html">&lt;meta property="se:long-description"&gt;</code> element surrounded by a <code class="html">&lt;![CDATA[ ... ]]&gt;</code> element. Once you’re done, run the <code class="path">clean</code> tool, which will remove the <code class="html">&lt;![CDATA[ ... ]]&gt;</code> element and escape the contained HTML for you.</p>
 			</li>
 			<li>
-				<p>Include the following element directly after the long description: <code class="html">&lt;meta property="meta-auth" refines="#long-description"&gt;https://standardebooks.org&lt;/meta&gt;</code></p>
+				<p>Include the following element directly after the long description: <code class="html">&lt;meta property="authority" refines="#long-description"&gt;https://standardebooks.org&lt;/meta&gt;</code></p>
 			</li>
 		</ul>
 		<h2>The <code class="html">&lt;dc:language&gt;</code> element</h2>


### PR DESCRIPTION
When I use "meta-auth" I receive the following warning with 

$ se build -c -o ../dist .

epubcheck v4.2.2 failed with:
WARNING(RSC-017): /home/josh/se/dist/poul-anderson_short-fiction.epub/epub/content.opf(94,58): Warning while parsing file: Use of the meta-auth property is deprecated

Check finished with warnings
$
