### PR TITLE
Add 'The Souls of Black Folk' and 'Cane' to wanted ebooks

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -462,6 +462,12 @@ require_once('Core.php');
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/46597">In Search of the Castaways</a> <i>Les Enfants du capitaine Grant</i> by Jules Verne</p>
 			</li>
+			<li>
+				<p><a href="https://www.gutenberg.org/ebooks/408">The Souls of Black Folk</a> by W. E. B. Du Bois</p>
+			</li>
+			<li>
+				<p><a href="https://www.gutenberg.org/ebooks/60093">Cane</a> by Jean Toomer</p>
+			</li>
 		</ul>
 		<h2>Advanced productions</h2>
 		<ul>

--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -465,12 +465,12 @@ require_once('Core.php');
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/408">The Souls of Black Folk</a> by W. E. B. Du Bois</p>
 			</li>
-			<li>
-				<p><a href="https://www.gutenberg.org/ebooks/60093">Cane</a> by Jean Toomer</p>
-			</li>
 		</ul>
 		<h2>Advanced productions</h2>
 		<ul>
+			<li>
+				<p><a href="https://www.gutenberg.org/ebooks/60093">Cane</a> by Jean Toomer</p>
+			</li>
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/28701">Short stories by W. W. Jacobs</a> (We already have Lady of the Barge; do we need an omnibus?)</p>
 			</li>


### PR DESCRIPTION
[_The Souls of Black Folk_](https://en.wikipedia.org/wiki/The_Souls_of_Black_Folk) is an incredibly influential book, and has a more or less permanent place in Project Gutenberg's top 50 most downloaded books.

[_Cane_ ](https://en.wikipedia.org/wiki/Cane_(novel)) is not as well known, but is considered a classic modernism, and is a good example of work from the Harlem Renaissance.

I put both these in the moderate difficulty section, since both are relatively short, but _Souls_ starts each chapter with a song, complete with music notation, and _Cane_ has a lot of poetry and somewhat interesting formatting.