### PR TITLE
Better background colour for homepage splash

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -293,9 +293,7 @@ article > h1{
 
 main.front-page h1{
 	text-align: center;
-	background:  url('/images/book.jpg');
-	background-size: cover;
-	background-position: center;
+	background: #29292b url('/images/book.jpg') center / cover;
 	border-bottom: 1px solid var(--border);
 	box-shadow: 0 0 10px rgba(0, 0, 0, .75);
 	width: calc(100% + 4rem);


### PR DESCRIPTION
If we set a dark background colour as well as the image it’ll show while the image is loading (or if the image fails to load). This colour is picked from the background of the image to reduce impact when it loads.

Here’s a screenshot with the main image purposefully toggled off.

<img width="1022" alt="Demo without image" src="https://user-images.githubusercontent.com/7414/88485626-89e89380-cf77-11ea-88ab-9b1433dc86e3.png">