### PR TITLE
Add --bare option, default to working directory clones

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -3,7 +3,7 @@ set -e
 set -o pipefail
 
 usage(){
-	fmt <<EOF
+	cat <<EOF
 DESCRIPTION
 	Syncs books from standardebooks.org GitHub org to specified folder.
 
@@ -13,6 +13,7 @@ USAGE
 	With -v or --verbosity 1, display general progress updates.
 	With -vv or --verbosity 2, display general progress updates and verbose git output.
 	With --update-only, only sync existing repositories, do not download new repositories.
+	With -b or --bare, clone a bare repository (for a server) instead of a working directory
 	With --token TOKEN, specify a GitHub access token to use for request. Useful for when you hit the rate limit.
 
 	DIRECTORY should be where the repositories should go.
@@ -48,6 +49,7 @@ verbosity=0
 updateOnly="false"
 githubToken=""
 target=""
+bare=""
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -74,6 +76,10 @@ while [ $# -gt 0 ]; do
 			check_arg '*[!0-9a-zA-Z]*' "$2" "Token is empty or contains illegal characters."
 			githubToken="$2"
 			shift 2
+			;;
+		-b|--bare)
+			bare="--bare"
+			shift 1
 			;;
 		*)
 			break ;;
@@ -164,13 +170,21 @@ fi
 repoUrls=$(printf "%s" "${repoUrls}" | grep -v -e "/tools.git\$" -e "/web.git\$" -e "/manual.git\$" | awk 'NF')
 
 printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
+	# make sure it's not an empty string
 	[ -n "${repoUrl}" ] || continue
-	[ -d "${repoUrl##*/}" ] && continue
 
+	# strip everything prior to the last segment of the name
 	repoName="${repoUrl##*/}"
+	if [ "${bare}" = "" ]; then
+		repoName="${repoName%.git}"
+	fi
+
+	# if the repo already exists, skip it (handled in the update above)
+	[ -d "${repoName}" ] && continue
+
 	repoNameLength=$(printf "%s" "${repoName}" | wc -m)
 	if [ "${repoNameLength}" -ge 100 ]; then
-		if dirs=( "${repoName%%.git}"*/ ) && [[ -d ${dirs[0]} ]]; then
+		if dirs=( "${repoName}"*/ ) && [[ -d ${dirs[0]} ]]; then
 			continue
 		fi
 	fi
@@ -180,9 +194,9 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 	fi
 
 	if [ "${verbosity}" -lt 2 ]; then
-		git clone -q --bare "${repoUrl}"
+		git clone -q ${bare} "${repoUrl}"
 	else
-		git clone -v --bare "${repoUrl}"
+		git clone -v ${bare} "${repoUrl}"
 	fi
 
 	if ! [ -d "${repoName}" ]; then
@@ -196,8 +210,11 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 		sed -E "s/<[^>]+?>//g" |
 		sed -E "s|url:https://standardebooks.org/ebooks/||g" |
 		sed -E "s|/|_|g").git"
+	if [ "${bare}" = "" ]; then
+		properName="${properName%.git}"
+	fi
 
-	if [ "${repoUrl##*/}" != "${properName}" ]; then
+	if [ "${repoName}" != "${properName}" ]; then
 		if [ "${verbosity}" -gt 0 ]; then
 			printf "Moving %s to %s\n" "${repoName}" "${properName}"
 		fi


### PR DESCRIPTION
It wasn't as easy as just removing the `--bare` from the `git clone` command. The script has a lot of logic revolving around the repository name, and that name is different for a bare (x.git) vs working directory (x) clone.

This makes the default working directory clones, and adds a `-b/--bare` option to get a server-side copy. I made WD the default because I guessed more people use that than use the server-side, plus I think it's the "least surprise" option. And someone needing a service-side copy know they need --bare.

I have tested it both with and without `--bare`, and everything seems to work. I get the proper kinds of repositories based on the option, and both updating and getting new ones work with and with the --bare. I'm currently downloading a complete copy of WDs; it's been going a half-hour or so without incident.

A couple of notes:
1. The `usage()` function at the top used `fmt` to output the text. That reformats everything as a paragraph that wraps at 65 characters. This meant each of the "With…" lines did not start on a separate line, but instead that whole block was treated as a single paragraph. That in turn caused options to get "lost" in the middle of a line. I tried two solutions:
    a. Putting a blank line between each of the "With…" lines, so that each is treated as a separate paragraph.
    b. Changing the `fmt` to `cat`.
The former still wraps everything at 65 characters, but adds an unnecessary empty line in between each option.
The latter doesn't wrap, but I don't see a big need to do that, anyway. Use whatever terminal width you have.
If you prefer the wrapping, just change it back to `fmt` and add an empty line after each "With…". (I really don't think you should leave it like it is; you can't "see" the options.)
2. I use different variable names in a couple of places, but that's because the existing script re-does work on a variable multiple times instead of just using a different variable where it's already done the work.
3.  I added a few comments to make it a little easier to tell what was happening and why.
4. I know you didn't write it, but do you know what lines 186-188 (checking repoName is >= 100 chars, etc.) are doing? Or, more to the point, _why_ it's doing it?
5. There's logic at the end of the script to rename the directory if the SE identifier is different than the repository name. Why would those ever be different?
6. I didn't try to deal with the errors I got last time at the very end of the clone. I'll try to look at that later.