### PR TITLE
Fix homepage link preview

### DIFF
--- a/templates/Header.php
+++ b/templates/Header.php
@@ -42,7 +42,7 @@ print("\n");
 	<link rel="alternate" type="application/rss+xml" title="Standard Ebooks - New Releases" href="https://standardebooks.org/rss/new-releases"/>
 	<link color="#394451" href="/safari-pinned-tab.svg" rel="mask-icon"/>
 	<meta content="#394451" name="theme-color"/>
-	<meta content="<?= Formatter::ToPlainText($title) ?>" property="og:title"/>
+	<meta content="<? if($title != ''){ ?><?= Formatter::ToPlainText($title) ?><? }else{ ?>Standard Ebooks<? } ?>" property="og:title"/>
 	<meta content="<?= $ogType ?? 'website' ?>" property="og:type"/>
 	<meta content="<?= SITE_URL . str_replace(SITE_URL, '', ($_SERVER['ORIG_PATH_INFO'] ?? $_SERVER['SCRIPT_URI'] ?? '')) ?>" property="og:url"/>
 	<meta content="<?= SITE_URL . ($coverUrl ?? '/images/logo.svg') ?>" property="og:image"/>

--- a/templates/Header.php
+++ b/templates/Header.php
@@ -45,7 +45,7 @@ print("\n");
 	<meta content="<? if($title != ''){ ?><?= Formatter::ToPlainText($title) ?><? }else{ ?>Standard Ebooks<? } ?>" property="og:title"/>
 	<meta content="<?= $ogType ?? 'website' ?>" property="og:type"/>
 	<meta content="<?= SITE_URL . str_replace(SITE_URL, '', ($_SERVER['ORIG_PATH_INFO'] ?? $_SERVER['SCRIPT_URI'] ?? '')) ?>" property="og:url"/>
-	<meta content="<?= SITE_URL . ($coverUrl ?? '/images/logo.svg') ?>" property="og:image"/>
+	<meta content="<?= SITE_URL . ($coverUrl ?? '/images/devices@2x.png') ?>" property="og:image"/>
 	<meta content="summary_large_image" name="twitter:card"/>
 	<meta content="@standardebooks" name="twitter:site"/>
 	<meta content="@standardebooks" name="twitter:creator"/>


### PR DESCRIPTION
I shared a link to this project with a friend on whatsapp and there was no link preview:

![IMG_4932](https://user-images.githubusercontent.com/531168/101369805-a0e1af80-38a0-11eb-9879-55edccfe8c7a.jpg)

[According to facebook](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fstandardebooks.org%2F):

> Unsupported Image File Extension
> Provided og:image URL, https://standardebooks.org/images/logo.svg does not have a supported extension.

I swapped the SVG logo for the homepage image because:

1. It's more visually appealing
2. It's what facebook is already using

I also took a look at twitter and there was no link preview. [According to twitter](https://cards-dev.twitter.com/validator):

> ERROR: Required meta tag missing (twitter:text:title)

[According to twitter's markup](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup), `og:title` is also accepted but on this page it's empty.

I added a fallback for this case.

Hopefully these two changes will fix the link previews.