### PR TITLE
Update wanted ebooks list with Romance of the Three Kingdoms

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -688,6 +688,9 @@ require_once('Core.php');
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/4300">Ulysses</a> by James Joyce (Part of the Modern Library’s 100 best novels)</p>
 			</li>
+			<li>
+				<p><a href="https://en.wikipedia.org/wiki/Romance_of_the_Three_Kingdoms">Romance of the Three Kingdoms</a> by Luo Guanzhong, translated by Charles Henry Brewitt-Taylor. This is a 1925 publication, transcription is required.</p>
+			</li>
 		</ul>
 		<h2>Uncategorized lists</h2>
 		<ul>


### PR DESCRIPTION
According to Wikipedia:

> *Romance of the Three Kingdoms* is a 14th‐century historical novel attributed to Luo Guanzhong. It is set in the turbulent years towards the end of the Han dynasty and the Three Kingdoms period in Chinese history, starting in 169 AD and ending with the reunification of the land in 280 by Western Jin. The novel is based primarily on the *Records of the Three Kingdoms*, written by Chen Shou.
>
> …
>
> *Romance of the Three Kingdoms* is acclaimed as one of the Four Great Classical Novels of Chinese literature; it has a total of 800,000 words and nearly a thousand dramatic characters (mostly historical) in 120 chapters. The novel is among the most beloved works of literature in East Asia, and its literary influence in the region has been compared to that of the works of Shakespeare on English literature. It is arguably the most widely read historical novel in late imperial and modern China. Herbert Giles stated that among the Chinese themselves, this is regarded as the greatest of all their novels.
>
> …
>
> A complete and faithful translation of the novel was published in two volumes in 1925 by Charles Henry Brewitt‐Taylor, a long time official of the Chinese Maritime Customs Service. The translation was well written, but lacked any supplementary materials such as maps or character lists that would aid Western readers; a 1959 reprint was published that included maps and an introduction by Roy Andrew Miller to assist foreign readers.

Since Brewitt‐Taylor’s translation seems well regarded and its copyright expires in less than a month, I’d like to put it on the list.