### PR TITLE
Update wanted ebooks list with Rizal’s Noli & Fili

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -553,6 +553,12 @@ require_once('Core.php');
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/9830">The Beautiful and the Damned</a> by F. Scott Fitzgerald</p>
 			</li>
+			<li>
+				<p><a href="https://www.gutenberg.org/ebooks/6737">Noli Me Tángere</a> by José Rizal, translated by Charles Derbyshire</p>
+			</li>
+			<li>
+				<p><a href="https://www.gutenberg.org/ebooks/10676">El filibusterismo</a> by José Rizal, translated by Charles Derbyshire</p>
+			</li>
 		</ul>
 		<h2>Advanced productions</h2>
 		<ul>


### PR DESCRIPTION
Wikipedia:

> *Noli Me Tángere*, Latin for "Touch me not", is an 1887 novel by José Rizal during the colonization of the Philippines by Spain to describe perceived inequities of the Spanish Catholic friars and the ruling government.
>
> Originally written in Spanish, the book is more commonly published and read in the Philippines in either Tagalog or English. Together with its sequel, *El filibusterismo* (Grade 10), the reading of *Noli* is obligatory for high school students (Grade 9) throughout the country. The two novels are widely considered the national epic of the Philippines and are adapted in many forms, such as operas, musicals, plays, and other forms of art.

The best public domain translations appear to be Charles Derbyshire’s, which are on Project Gutenberg.
I’m not an expert, but my impression is Derbyshire’s translations are considered serviceable—having the usual criticisms of translations by foreign non‐native speakers, but widely known and decently respected. No other English translations have imminent copyright expirations (nearest are 1956/1957 by Camilo Osías, 1961/1962 by Leon Ma. Guerrero III).

*Noli Me Tángere* is about 175,000 words; *El filibusterismo* is about 115,000.

I browsed through the Gutenberg versions. They both appear to preserve italics and accents. Footnotes are plentiful as are blockquotes (poems, signs, letters, etc.).