### PR TITLE
Make font white for book number in collections view

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1134,7 +1134,7 @@ main.ebooks > ol a[tabindex][data-ordinal]::before{
 	font-size: .75rem;
 	font-weight: bold;
 	font-family: "League Spartan", sans-serif;
-	color: white;
+	color: var(--dark-body-text);
 }
 
 main.ebooks > ol a[tabindex]:hover{

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1134,6 +1134,7 @@ main.ebooks > ol a[tabindex][data-ordinal]::before{
 	font-size: .75rem;
 	font-weight: bold;
 	font-family: "League Spartan", sans-serif;
+	color: white;
 }
 
 main.ebooks > ol a[tabindex]:hover{


### PR DESCRIPTION
In the collections view, there is a dark square (`rgba(0, 0, 0, .75)`) containing the ordinal number for the book, however because the font is dark, the text isn't visible. This PR sets the font in that selector to white. Not sure if pure `fff` white is the right color here, so looking for feedback on the the right shade/variable to use.

Before:
<img width="797" alt="se_collections_before" src="https://user-images.githubusercontent.com/1933219/103452708-4e649a80-4c76-11eb-9f0f-351749107fc0.png">


After:
<img width="786" alt="se_collections_after" src="https://user-images.githubusercontent.com/1933219/103452706-460c5f80-4c76-11eb-88bb-8aa60b921342.png">
