### PR TITLE
Update wanted ebooks: Jefferson, Mahan

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -734,7 +734,7 @@ require_once('Core.php');
 				<p>Hadrian the Seventh by Frederick Rolfe (No PG edition yet but <a href="https://www.pgdp.net/c/project.php?id=projectID5d6cced48cdf7&amp;detail_level=3">PGDP transcription is in progress</a>. Part of the Guardian 2015 collection.)</p>
 			</li>
 			<li>
-				<p>The Winning of the West (<a href="https://gutenberg.org/ebooks/11941">Volume 1</a>, <a href="https://gutenberg.org/ebooks/11942">Volume 2</a>, <a href="https://gutenberg.org/ebooks/11943">Volume 3</a>, <a href="https://gutenberg.org/ebooks/11944">Volume 4</a>) by Theodore Roosevelt</p>
+				<p><a href="https://gutenberg.org/ebooks/45847">The Autobiography of Thomas Jefferson</a>, by Thomas Jefferson</p>
 			</li>
 		</ul>
 		<h2>Uncategorized lists</h2>


### PR DESCRIPTION
Revising #118 a bit: it was suggested that we would be interested in Alfred Thayer Mahan’s *The Influence of Sea Power Upon History* over Roosevelt’s *The Naval War of 1812*. I protested that *Sea Power* and its sequel don’t cover the War of 1812. I’ve since learned that Mahan in fact published a third book specifically covering that war, so I agree that Roosevelt’s *1812* is obviated.

I’m removing Roosevelt’s *The Winning of the West*, as it turns out to not be autobiographical, and he is not particularly notable as a historian (except for *1812*).

I looked into other autobiographies of U.S. presidents. I think Jefferson’s is worth adding to the list. It exists on Gutenberg, is about 40k words plus 20k words of appendices, and covers his life up to 1791. I listed it as advanced because it has a few spots with tricky formatting.

Some others that I investigated but decided not to add:

There is a memoir of John Adams within his papers but it is very short. I do think productions of [the Adams–Jefferson letters](https://en.wikipedia.org/wiki/Thomas_Jefferson#Reconciliation_with_Adams) and of John and Abigail Adams’s letters to each other would be worthwhile for SE, but both would require a lot of research.

James Madison’s autobiography exists as a [24‐page manuscript](https://www.loc.gov/item/mjm022931/).

James Buchanan wrote [*Mr. Buchanan’s Administration on the Eve of Rebellion*](https://archive.org/details/DKC0010). It was looked upon disfavorably as an attempt to defend his failure to prevent the Civil War.

Martin Van Buren wrote an autobiography. It is [over 800 pages long](https://archive.org/details/autobiographyma00buregoog) and by all accounts a real yawner.

The diaries of [James K. Polk](https://archive.org/details/diaryofjameskpol00polk) and [James A. Garfield](https://archive.org/details/diaryofjamesagar04harr) during their presidencies have both been published. I must admit I can’t recall anything noteworthy about either President (although in Garfield’s defense, he was shot and died six months in, so he didn’t have much of a chance).

I’m not aware of any other U.S. Presidents who have public domain autobiographies. There may be a few if one digs through collections of their papers but I don’t think it’s worth the effort.

The only one expiring soon is Calvin Coolidge’s (published 1929). That would be a good fit for our collection.