### PR TITLE
Add a simple nav bar to web versions of books

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -320,7 +320,8 @@ do
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s|<title>|<title>${workTitle} - |g"
 
 		# Add the nav to each page
-		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended 's/<body(.*?)>/<body\1><header><nav><ul><li><a href="\/">Standard Ebooks<\/a><\/li><li><a href="\.">Table of contents<\/a><\/li><\/ul><\/nav><\/header>/'
+		bookUrl=$(grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">.+?</dc:identifier>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/.*?url:(.*?)<.*/\1/g")
+		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s%<body(.*?)>%<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>%"
 
 		# Adjust sponsored links in the colophon
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -290,6 +290,9 @@ do
 			# We do this first because the tweaks below shouldn't apply to the single-page file
 			se recompose-epub --xhtml --output "${workDir}"/single-page.xhtml --extra-css-file="${webRoot}/www/css/web.css" "${workDir}"
 
+			# Add a navbar with a link back to the homepage
+			sed --in-place --regexp-extended 's/<body(.*?)>/<body\1><header><nav><ul><li><a href="\/">Standard Ebooks<\/a><\/li><\/ul><\/nav><\/header>/' "${workDir}"/single-page.xhtml
+
 			# Adjust sponsored links in the colophon
 			sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/single-page.xhtml
 
@@ -298,7 +301,7 @@ do
 			fi
 		fi
 
-		# Make some compatibilty adjustments for the individual XHTML files
+		# Make some compatibility adjustments for the individual XHTML files
 
 		# Remove instances of the .xhtml filename extension in the source text
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place 's/\.xhtml//g'
@@ -315,6 +318,9 @@ do
 		# Add the work title to <title> tags in the source text
 		workTitle=$(grep --only-matching --extended-regexp "<dc:title id=\"title\">(.+?)</dc:title>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/<[^>]+?>//g")
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s|<title>|<title>${workTitle} - |g"
+
+		# Add the nav to each page
+		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended 's/<body(.*?)>/<body\1><header><nav><ul><li><a href="\/">Standard Ebooks<\/a><\/li><li><a href="\.">Table of contents<\/a><\/li><\/ul><\/nav><\/header>/'
 
 		# Adjust sponsored links in the colophon
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -291,7 +291,7 @@ do
 			se recompose-epub --xhtml --output "${workDir}"/single-page.xhtml --extra-css-file="${webRoot}/www/css/web.css" "${workDir}"
 
 			# Adjust sponsored links in the colophon
-			sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/single-page.
+			sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/single-page.xhtml
 
 			if [ "${verbose}" = "true" ]; then
 				printf "Done.\n"

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -321,7 +321,7 @@ do
 
 		# Add the nav to each page
 		bookUrl=$(grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">.+?</dc:identifier>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/.*?url:(.*?)<.*/\1/g")
-		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s%<body(.*?)>%<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>%"
+		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s%<body(.*?)>%<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}\">Back to ebook</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>%"
 
 		# Adjust sponsored links in the colophon
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml

--- a/vms/docker/Dockerfile
+++ b/vms/docker/Dockerfile
@@ -2,7 +2,14 @@ FROM ubuntu:20.04
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl apache2 apache2-utils libfcgi0ldbl task-spooler
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y sudo imagemagick openjdk-8-jre python3 pip calibre
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN pip install standardebooks
+
+RUN sudo addgroup committers
+RUN sudo adduser se
+RUN sudo usermod -g committers se
 
 RUN mkdir -p /standardebooks.org/web
 RUN mkdir /var/log/local

--- a/www/css/web.css
+++ b/www/css/web.css
@@ -4,7 +4,7 @@ body{
 	font-family: Georgia, serif;
 	font-size: 18px;
 	padding: 0 3em;
-	margin: 6em auto 3em;
+	margin: 8em auto 3em;
 	max-width: 55ch;
 }
 
@@ -18,15 +18,10 @@ body > header{
 	box-shadow: 0 0 3px #ccc;
 }
 
-@media(max-width: 96ch){
-	body > header{
-		position: fixed;
-	}
-}
-
 body > header ul{
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 	list-style: none;
 	margin: 0;
 	padding: 0.5em 1em;
@@ -34,10 +29,21 @@ body > header ul{
 
 body > header li:first-child > a{
 	display: block;
-	width: 90px;
-	height: 21px;
+	width: 180px;
+	height: 42px;
 	background: no-repeat center/100% url(/images/logo-full.svg);
-	text-indent: -999em;
+	font-size: 0;
+}
+
+@media(max-width: 96ch){
+	body > header{
+		position: fixed;
+	}
+
+	body > header li:first-child > a{
+		width: 90px;
+		height: 21px;
+	}
 }
 
 body > nav,

--- a/www/css/web.css
+++ b/www/css/web.css
@@ -4,8 +4,40 @@ body{
 	font-family: Georgia, serif;
 	font-size: 18px;
 	padding: 0 3em;
-	margin: 3em auto;
+	margin: 6em auto 3em;
 	max-width: 55ch;
+}
+
+body > header{
+	position: absolute;
+  left: 0;
+	right: 0;
+	top: 0;
+	background: #fff;
+	border-bottom: 1px solid #999;
+	box-shadow: 0 0 3px #ccc;
+}
+
+@media(max-width: 96ch){
+	body > header{
+		position: fixed;
+	}
+}
+
+body > header ul{
+	display: flex;
+	justify-content: space-between;
+	list-style: none;
+	margin: 0;
+	padding: 0.5em 1em;
+}
+
+body > header li:first-child > a{
+	display: block;
+	width: 90px;
+	height: 21px;
+	background: no-repeat center/100% url(/images/logo-full.svg);
+	text-indent: -999em;
 }
 
 body > nav,
@@ -43,7 +75,8 @@ nav[epub|type~="toc"] ol{
 }
 
 @media(prefers-color-scheme: dark){
-	body{
+	body,
+	body > header{
 		background: #222222;
 		color: #ffffff;
 	}
@@ -61,6 +94,7 @@ nav[epub|type~="toc"] ol{
 		color: #dda0dd;
 	}
 
+	body > header li:first-child > a,
 	img[epub|type~="se:image.color-depth.black-on-transparent"]{
 		filter: invert(1);
 	}

--- a/www/css/web.css
+++ b/www/css/web.css
@@ -20,11 +20,19 @@ body > header{
 
 body > header ul{
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
 	list-style: none;
 	margin: 0;
 	padding: 0.5em 1em;
+}
+
+body > header li{
+	margin-left: 1.5em;
+}
+
+body > header li:first-child{
+	margin-left: 0;
+	margin-right: auto;
 }
 
 body > header li:first-child > a{


### PR DESCRIPTION
This is a really simple nav bar that just sits at the top of the page on desktop, but on portrait iPad and lower will remain fixed in place. The nav bar has two options: an SE logo that goes back to the homepage, and a “Table of contents” link that goes to the ToC. For single-page, we drop the ToC link as the user can just scroll to the top of the page anyway.

**Desktop view, showing fixed nav:**

<img width="776" alt="Screenshot 2021-07-26 at 21 22 42" src="https://user-images.githubusercontent.com/7414/127050222-677f9230-327e-42d4-9356-bbe00c79b511.png">

**Mobile view, showing docked nav:**

<img width="576" alt="Screenshot 2021-07-26 at 21 24 51" src="https://user-images.githubusercontent.com/7414/127050217-e752c4e5-3862-46a7-aeee-9be6b8a101d8.png">

**Single page view, with no link to ToC:**

<img width="597" alt="Screenshot 2021-07-26 at 21 25 20" src="https://user-images.githubusercontent.com/7414/127050224-82d92a2c-70bf-48a2-9084-7db06717c5a5.png">

**Dark mode view:**

<img width="599" alt="Screenshot 2021-07-26 at 21 25 48" src="https://user-images.githubusercontent.com/7414/127050227-270a1536-83ff-47c4-bef8-715c507087f6.png">


This PR also updates the Dockerfile to get `deploy-ebook-to-www` working, and fixes a bug with missing nofollows on single-page sponsored colophons.

Fixes https://github.com/standardebooks/web/issues/140.