### PR TITLE
Increase JPEG quality of 242px thumbnails to 85%

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -226,7 +226,7 @@ do
 		sed -i "s/cover\.jpg/${urlSafeIdentifier}\.jpg/g" "${imgWorkDir}/${urlSafeIdentifier}.svg"
 
 		# Resize and compress the image (formula from Google Page Speed Insights)
-		convert -resize "242" -sampling-factor 4:2:0 -strip -quality 80 -colorspace RGB -interlace JPEG "${imgWorkDir}/${urlSafeIdentifier}.svg" "${imgWorkDir}/${urlSafeIdentifier}-cover.jpg"
+		convert -resize "242" -sampling-factor 4:2:0 -strip -quality 85 -colorspace RGB -interlace JPEG "${imgWorkDir}/${urlSafeIdentifier}.svg" "${imgWorkDir}/${urlSafeIdentifier}-cover.jpg"
 		convert -resize "484" -sampling-factor 4:2:0 -strip -quality 80 -colorspace RGB -interlace JPEG "${imgWorkDir}/${urlSafeIdentifier}.svg" "${imgWorkDir}/${urlSafeIdentifier}-cover@2x.jpg"
 
 		# go-avif is extremely slow and should be replaced with something faster ASAP


### PR DESCRIPTION
[I’ve whined before](https://github.com/standardebooks/tools/issues/405) about how *The Great Gatsby*’s cover is badly affected by JPEG artifacts in the “Browse Ebooks” page. This one really sticks out like a sore thumb…nail. It may affect others with similar characteristics too (solid color with scattered details?).

I’d like to propose bumping the quality on these smallest images to 85%, the maximum quality suggested by Google Page Speed Insights. It makes the artifacting a lot less noticeable, and in my simplistic tests increases the filesize by about 25%, or under 2 kilobytes per thumbnail. That seems negligible to me—although of course I’m not the one who has to cover bandwidth and placate PageRank.

90% provides visibly better results but more than doubles the filesize, so that seems not so useful.