### PR TITLE
Add note to run 'se clean' when completing content.opf

### DIFF
--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -600,7 +600,7 @@ proceed to seal up my confession, I bring the life of that unhappy Henry Jekyll 
 				<h2>Complete content.opf</h2>
 				<p><code class="path">content.opf</code> is the file that contains the ebook metadata like author, title, description, and reading order. Most of it will be filling in that basic information, and including links to various resources related to the text. We already completed the manifest and spine in an earlier step.</p>
 				<p><code class="path">content.opf</code> is standardized. See the <a href="/manual/latest/9-metadata">Metadata section of the <abbr class="acronym">SEMoS</abbr></a> for details on how to fill it out.</p>
-				<p>The last details to fill out here will be the short and long descriptions, verifying any Wikipedia links that <code class="bash"><b>se</b> create-draft</code> automatically found, adding cover artist metadata, filling out any missing author or contributor metadata, and adding your own metadata as the ebook producer.</p>
+				<p>The last details to fill out here will be the short and long descriptions, verifying any Wikipedia links that <code class="bash"><b>se</b> create-draft</code> automatically found, adding cover artist metadata, filling out any missing author or contributor metadata, and adding your own metadata as the ebook producer. If you wrote the long description in unescaped HTML, run <code class="bash"><b>se</b> clean</code> to convert the long description to escaped HTML.</p>
 				<p>Once you’re done, commit:</p>
 				<code class="terminal"><span><b>git</b> commit -am <i>"Complete content.opf"</i></span></code>
 			</li>


### PR DESCRIPTION
I know the manual mentions that `se clean` will escape the HTML in long description, but since it came up today in a review, I thought maybe it was worth mentioning it needed to be run in the content.opf section of the Step-by-Step guide?

If not, no biggie.