### PR TITLE
Fix typo in How to Use Our Ebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If run successfully, it should output `[OK] No errors`.
 
 # Contributing
 
-Before submitting design contributions, please discuss them with the Standard Ebooks lead. While we encourage discussion and contributions, we can’t guarantee that unsoliticed design contributions will be accepted. You can open an issue to discuss potential design contributions with us before you begin.
+Before submitting design contributions, please discuss them with the Standard Ebooks lead. While we encourage discussion and contributions, we can’t guarantee that unsolicited design contributions will be accepted. You can open an issue to discuss potential design contributions with us before you begin.
 
 ## Help wanted
 

--- a/www/help/how-to-use-our-ebooks.php
+++ b/www/help/how-to-use-our-ebooks.php
@@ -53,7 +53,7 @@ require_once('Core.php');
 					</ol>
 					<h4 id="kindle-method-2">Method 2 - Download Directly to Kindle</h4>
 					<p>This method won’t add the ebook to your Kindle library, but your Kindle will remember your reading position.</p>
-					<p>This method also won’t add include a cover imgae. If you want a cover image, use <a href="#kindle-method-1">method 1</a>.</p>
+					<p>This method also won’t add include a cover image. If you want a cover image, use <a href="#kindle-method-1">method 1</a>.</p>
 					<ol>
 						<li>
 							<p>From your Kindle’s home screen, tap the 3 dots in the upper-right corner.</p>


### PR DESCRIPTION
imgae -> image in How to Use Our Ebooks -> Method 2 - Download Directly to Kindle
