### PR TITLE
Restrict Internet Archive source to scans only

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -404,7 +404,7 @@ class Ebook{
 			elseif(mb_stripos($e, 'gutenberg.ca/') !== false){
 				$this->Sources[] = new EbookSource(SOURCE_PROJECT_GUTENBERG_CANADA, $e);
 			}
-			elseif(mb_stripos($e, 'archive.org/') !== false){
+			elseif(mb_stripos($e, 'archive.org/details') !== false){
 				$this->Sources[] = new EbookSource(SOURCE_INTERNET_ARCHIVE, $e);
 			}
 			elseif(mb_stripos($e, 'hathitrust.org/') !== false){


### PR DESCRIPTION
We have been using the Wayback Machine sometimes to create a stable link to a transcription if it has gone down in the past, e.g. [*Lyrical Ballads*](https://standardebooks.org/ebooks/william-wordsworth_samuel-taylor-coleridge/lyrical-ballads). The logic to categorize sources on the website lumps all Internet Archive sources as scans. It should only treat an IA source as a scan if it has the `/details` path (this is also consistent with our lint rule for Internet Archive paths).