### PR TITLE
Update wanted ebooks list: Two Years Before the Mast

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -419,6 +419,9 @@ require_once('Core.php');
 			<li>
 				<p>Epictetus’s “Enchiridion” and fragments as a Short Works compilation, in <a href="http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0237%3Atext%3Denc">Thomas Wentworth Higginson’s translation</a>, to supersede our <a href="/ebooks/epictetus/short-works/george-long">current edition</a> of his short works in George Long’s inferior translation</p>
 			</li>
+			<li>
+				<p><a href="https://gutenberg.org/ebooks/2055">Two Years Before the Mast</a> by Richard Henry Dana, <abbr>Jr.</abbr></p>
+			</li>
 		</ul>
 		<h2>Advanced productions</h2>
 		<ul>


### PR DESCRIPTION
Wikipedia: [Book](https://en.wikipedia.org/wiki/Two_Years_Before_the_Mast), [Author](https://en.wikipedia.org/wiki/Richard_Henry_Dana_Jr.)

In terms of notability, it was included in Harvard Classics, was adapted into a popular film, and Herman Melville (a contemporary) spoke highly of it.

In terms of complexity, there are some poems and footnotes. PG has a biographical preface that can be dropped, and a labeled diagram of a ship that could be kept or could be dropped. Typography will need some care: replacing ASCII apostrophes with primes in coordinates; replacing asterisked elisions with three‐em dashes; missing italics (plenty of ship names). 167,000 words.