### PR TITLE
Make sure that headers scrolled in view on mobile

### DIFF
--- a/www/css/web.css
+++ b/www/css/web.css
@@ -123,4 +123,8 @@ and will just drop this entire query together if it's included. */
 		margin-bottom: 2em;
 		margin-top: 2em;
 	}
+
+	[id]{
+		scroll-margin-top: 3em;
+	}
 }


### PR DESCRIPTION
Currently, when clicking on a ToC link in a single page web version, the title for that section is hidden under the fixed banner. We can use `scroll-margin-top` to add a little additional scroll amount to scroll the header into view. `3em` matches the current top margin of `3em` on headings and hgroups.