### PR TITLE
Add chapter navigation footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If everything went well you should now be able to open your web browser and visi
 mkdir /standardebooks.org/ebooks/
 cd /standardebooks.org/ebooks/
 git clone --bare https://github.com/standardebooks/david-lindsay_a-voyage-to-arcturus
-/standardebooks.org/web/scripts/deploy-ebook-to-www david-lindsay_a-voyage-to-arcturus
+/standardebooks.org/web/scripts/deploy-ebook-to-www david-lindsay_a-voyage-to-arcturus.git
 ```
 
 If everything went well, `https://standardebooks.test/ebooks` will show the one ebook you deployed.

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -339,8 +339,11 @@ do
 		workTitle=$(grep --only-matching --extended-regexp "<dc:title id=\"title\">(.+?)</dc:title>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/<[^>]+?>//g")
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s|<title>|<title>${workTitle} - |g"
 
-		# Add the nav to each page
+		# Add the header nav to each page
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s%<body(.*?)>%<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}\">Back to ebook</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>%"
+
+		# Add a chapter navigation footer to each page
+		"${scriptsDir}"/inject-chapter-navigation-footer "${workDir}"/src/epub "${bookUrl}"
 
 		# Adjust sponsored links in the colophon
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -1,0 +1,43 @@
+#!/usr/bin/php
+<?
+if(count($argv) < 3){
+	print 'Expected usage: inject-chapter-navigation-footer <epubDirectory> <bookUrl>';
+	exit(1);
+}
+$epubDirectory = $argv[1];
+$bookUrl = $argv[2];
+
+// Parse the order of chapters from the table of contents.
+$doc = new DOMDocument();
+libxml_use_internal_errors(true); // Suppress warnings from output.
+$doc->loadHTMLFile($epubDirectory . '/toc.xhtml');
+libxml_clear_errors();
+$toc = $doc->getElementById('toc');
+if($toc){
+	$chapterLinks = array();
+	foreach($toc->getElementsByTagName('a') as $link){
+		$obj = new stdClass();
+		$obj->Path = $link->getAttribute('href');
+		$obj->Name = $link->textContent;
+
+		// Only include links pointing to actual files (e.g. skip href="text/chapter-7#panawes-story").
+		if(file_exists($epubDirectory . '/' . $obj->Path . '.xhtml')){
+			$chapterLinks[] = $obj;
+		}
+	}
+
+	for($i = 0; $i < count($chapterLinks); $i++){
+		$previousObj = $i > 0 ? $chapterLinks[$i - 1] : null;
+		$nextObj = $i < count($chapterLinks) - 1 ? $chapterLinks[$i + 1] : null;
+
+		$fileName = $epubDirectory . '/' . $chapterLinks[$i]->Path . '.xhtml';
+		$chapter = file_get_contents($fileName);
+		// Inject the navigation footer.
+		$previousLink = $previousObj ? sprintf('<a href="%s"><em>Previous:</em> %s</a>', $bookUrl . '/' . $previousObj->Path, htmlspecialchars($previousObj->Name)) : '';
+		$nextLink = $nextObj ? sprintf('<a href="%s"><em>Next:</em> %s</a>', $bookUrl . '/' . $nextObj->Path, htmlspecialchars($nextObj->Name)) : '';
+		$footer = sprintf('<footer><ul><li>%s</li><li>%s</li></ul></footer>', $previousLink, $nextLink);
+		$chapter = str_replace('</body>', $footer . '</body>', $chapter);
+		file_put_contents($fileName, $chapter);
+	}
+}
+?>

--- a/www/css/web.css
+++ b/www/css/web.css
@@ -1,5 +1,9 @@
 @namespace epub "http://www.idpf.org/2007/ops";
 
+html{
+	position: relative;
+}
+
 body{
 	font-family: "Georgia", serif;
 	font-size: 18px;
@@ -49,6 +53,28 @@ body > header li:first-child > a{
 
 body > header li:first-child > a:hover{
 	transform: scale(1.025) rotate(1deg);
+}
+
+body > footer{
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+}
+
+body > footer ul{
+	display: flex;
+	justify-content: space-between;
+	margin: 0;
+	padding: 0.5em 1em;
+	list-style: none;
+}
+
+body > footer li{
+	max-width: 40%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 body > section[epub|type~="titlepage"],


### PR DESCRIPTION
I use the web interface for reading and one personal gripe is the lack of previous/next controls when reaching the end of a chapter. Using the back button to go back to the table of contents works but I frequently access chapters from bookmarks.

I tried my hand at implementing such a feature and I believe I have everything working.

### Screenshot:
![image](https://user-images.githubusercontent.com/13722457/200140259-42424273-5196-45df-9e47-bed9c9358cd7.png)

### Missing one of previous/next:
![image](https://user-images.githubusercontent.com/13722457/200140207-eca3795d-6e02-4498-aee0-bda79c5325fb.png)

### Titles too long relative to the screen width:
![image](https://user-images.githubusercontent.com/13722457/200141414-3296fe45-5622-4fe2-bf87-081a3725af03.png)

### Dark mode:
![image](https://user-images.githubusercontent.com/13722457/200140403-56747e31-458c-4598-970b-ff5c4c811f31.png)
