### PR TITLE
Update wanted ebooks list: The Travels of Marco Polo

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -578,6 +578,9 @@ require_once('Core.php');
 			<li>
 				<p><a href="https://archive.org/details/blindmice00compgoog/page/n6/mode/2up">Blind Mice</a> by Cyril Kay Scott (Transcription required.)</p><!--patron-->
 			</li>
+			<li>
+				<p>The Travels of Marco Polo by Rustichello da Pisa, translated by Henry Yule (<a href="https://gutenberg.org/ebooks/10636">volume 1</a>, <a href="https://gutenberg.org/ebooks/12410">volume 2</a>)</p>
+			</li>
 		</ul>
 		<h2>Uncategorized lists</h2>
 		<ul>


### PR DESCRIPTION
[Wikipedia](https://en.wikipedia.org/wiki/The_Travels_of_Marco_Polo):

> *The Travels of Marco Polo* is a 13th-century travelogue written down by Rustichello da Pisa from stories told by Italian explorer Marco Polo. It describes Polo's travels through Asia between 1271 and 1295, and his experiences at the court of Kublai Khan.
>
> Economic historian Mark Elvin concludes that recent work “demonstrates by specific example the ultimately overwhelming probability of the broad authenticity” of Polo's account, and that the book is, “in essence, authentic, and, when used with care, in broad terms to be trusted as a serious though obviously not always final, witness.”
>
> *The Travels* was a rare popular success in an era before printing.

By my estimate, the main work is about 103,000 words; the footnotes add about 367,000 words; the prefaces add about 92,000 words. It may be that only the main body is worth keeping.