### PR TITLE
Fix Docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"files": ["lib/Constants.php", "lib/CoreFunctions.php"]
 	},
 	"require": {
-		"thecodingmachine/safe": "^1.0.0",
+		"thecodingmachine/safe": "^1.3.3",
 		"phpmailer/phpmailer": "6.6.0",
 		"ramsey/uuid": "4.2.3",
 		"gregwar/captcha": "1.1.9",

--- a/vms/docker/Dockerfile
+++ b/vms/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl apache2 apache2-utils libfcgi0ldbl task-spooler libaprutil1-dbd-mysql attr libapache2-mod-xsendfile
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip apache2 apache2-utils libfcgi0ldbl task-spooler libaprutil1-dbd-mysql attr libapache2-mod-xsendfile
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y sudo imagemagick openjdk-8-jre python3 pip calibre
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
We’d had reports of Docker not working (https://github.com/standardebooks/web/issues/164) but I hadn’t been able to replicate. During a new install I ended up with the same problems, which let me debug why I’d previously not seen the problem.

First up, there was a problem with safe, where we needed [a specific newer version](https://github.com/thecodingmachine/safe/releases/tag/v1.3.2) to work with our current setup. Technically this isn’t a required change (`^1.0.0` should be satisfied by a 1.3.2 package) but as it’s also satisfied by lower packages we should fix it.

Secondly, there was a problem with Composer installing packages in the first place. What had happened on my system was that I’d previously installed Composer in my macOS environment and ran `composer install`, so I had a working set of packages in my repo ready for the Docker image to use. This meant that when the image’s `composer install` silently failed due to not being able to contact the outside world, the site carried on working regardless and I never noticed. So the second commit installs the necessary extra `php-` packages and allows Composer to contact the outside world.

This gets my new install back to a working state.