### PR TITLE
Don't escape forward slash in grep expression

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -244,7 +244,7 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 
 	# get the last segment of the dc:identifier from the metadata
 	properName="$(git -C "${repoName}" show HEAD:src/epub/content.opf |
-		grep -oE "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+<\/dc:identifier>" |
+		grep -oE "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+</dc:identifier>" |
 		sed -E "s/<[^>]+?>//g" |
 		sed -E "s|url:https://standardebooks.org/ebooks/||g" |
 		sed -E "s|/|_|g").git"


### PR DESCRIPTION
Fixes a warning with GNU Grep 3.8:

```
grep: warning: stray \ before /
```