### PR TITLE
sync-ebooks: Don't rename repository if target directory already exists

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -255,9 +255,15 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 	# if for some reason the repository name isn't the same as the identifier (they are identical
 	# 99% of the time), rename the directory to be the identifier name; not sure why this is done, either
 	if [ "${repoName}" != "${properName}" ]; then
-		if [ "${verbosity}" -gt 0 ]; then
-			printf "Moving %s to %s\n" "${repoName}" "${properName}"
+		if [ -d "${properName}" ]; then
+			if [ "${verbosity}" -gt 0 ]; then
+				printf "Not moving %s to %s: directory exists\n" "${repoName}" "${properName}"
+			fi
+		else
+			if [ "${verbosity}" -gt 0 ]; then
+				printf "Moving %s to %s\n" "${repoName}" "${properName}"
+			fi
+			mv "${repoName}" "${properName}"
 		fi
-		mv "${repoName}" "${properName}"
 	fi
 done

--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -213,7 +213,8 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 	# if the repo already exists, skip it (handled in the update above)
 	[ -d "${repoName}" ] && continue
 
-	# it's not clear what this is doing, or more specifically why it's doing it
+	# if the repository name has been truncated due to GitHub's name length limits,
+	# but a local clone with the full name exists, don't attempt to clone it again
 	repoNameLength=$(printf "%s" "${repoName}" | wc -m)
 	if [ "${repoNameLength}" -ge 100 ]; then
 		if dirs=( "${repoName}"*/ ) && [[ -d ${dirs[0]} ]]; then

--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -215,9 +215,9 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 
 	# if the repository name has been truncated due to GitHub's name length limits,
 	# but a local clone with the full name exists, don't attempt to clone it again
-	repoNameLength=$(printf "%s" "${repoName}" | wc -m)
+	repoNameLength=$(printf "%s" "${repoName%.git}" | wc -m)
 	if [ "${repoNameLength}" -ge 100 ]; then
-		if dirs=( "${repoName}"*/ ) && [[ -d ${dirs[0]} ]]; then
+		if dirs=( "${repoName%.git}"*/ ) && [[ -d ${dirs[0]} ]]; then
 			continue
 		fi
 	fi


### PR DESCRIPTION
The rename code doesn’t behave as intended if the directory already exists, silently moving the old directory into the new directory rather than renaming it. Handling this gives a visible diagnostic instead of invisibly misbehaving, and also allows the script to continue without terminating early.