### PR TITLE
Two minor process improvements to the step-by-step guides

### DIFF
--- a/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
+++ b/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
@@ -7,6 +7,10 @@ require_once('Core.php');
 		<p>After an ebook production is completed, it must go through rounds of review before it is published to ensure the appropriate production quality is assured. Reviewers are assigned by the <a href="/about#editor-in-chief">editor-in-chief</a>, and may be a member of the <a href="/about#editors">editorial staff</a>, or an experienced Standard Ebooks producer. Below is a helpful step-by-step checklist for reviewers of ebook productions. The checklist is by no means exhaustive, but serves as a good starting point for the proofreading process. Reviewers should keep in mind the standards enumerated in the <a href="/manual">Manual of Style</a>, and note any discrepancies not listed below. Before any review steps, ensure the most recent version of the SE toolset is installed.</p>
 		<ol>
 			<li>
+				<h2>Lint</h2>
+				<p>Run <code class="bash"><b>se</b> lint <u>.</u></code> at the root of the project directory. If <code>lint</code> surfaces any nontrivial errors, you should direct the producer to fix the errors before proceeding. If there are false positives, the producer should create an <code>se-lint-ignore.xml</code> to suppress the false positives.</p>
+			</li>
+			<li>
 				<h2>Typogrify</h2>
 				<p>Run <code class="bash"><b>se</b> typogrify <u>.</u></code> at the root of the project directory. The <code>typogrify</code> command is almost always correct, but sometimes not all changes it makes should be accepted. To go over the changes <code>typogrify</code> may have made, run the following <code class="bash"><b>git</b></code> command to also highlight changes made to invisible or hard to differentiate Unicode characters:</p>
 				<code class="terminal"><b>git</b> diff -U0 --word-diff-regex=.</code>
@@ -159,7 +163,7 @@ require_once('Core.php');
 				</ul>
 			</li>
 			<li>
-				<h2>Lint</h2>
+				<h2>Lint again</h2>
 				<p>Run a final <code class="bash"><b>se</b> lint <u>.</u></code> check, and ensure it is silent. If any warnings and errors are produced, they must be noted and addressed.</p>
 			</li>
 			<li>

--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -233,7 +233,8 @@ proceed to seal up my confession, I bring the life of that unhappy Henry Jekyll 
 					</li>
 					<li>
 						<p><a href="/manual/latest/8-typography#8.3.3">Text in all caps</a>. Text in all caps is almost never correct, and should either be converted to lowercase with the <code class="html"><span class="p">&lt;</span><span class="nt">em</span><span class="p">&gt;</span></code> element (for spoken emphasis), <code class="html"><span class="p">&lt;</span><span class="nt">strong</span><span class="p">&gt;</span></code> (for extreme spoken emphasis), or <code class="html"><span class="p">&lt;</span><span class="nt">b</span><span class="p">&gt;</span></code> (for unsemantic small caps, like in storefront signs).</p>
-						<p>Use this <strong>case-sensitive</strong> regex to find text in all caps: <code class="regex">(?<span class="p">&lt;</span>!en-)(?<span class="p">&lt;</span>!z3998:roman">)(?<span class="p">&lt;</span>![A-Z])[A-Z]{2,}(?!")</code></p>
+						<p>Use the following command to check for instance of all caps:</p>
+						<code class="terminal"><b>se</b> xpath <i>"//p//text()[re:test(., '[A-Z]{2,}') and not(contains(., 'OK') or contains(., 'SOS')) and not(parent::abbr or parent::var or parent::a or parent::*[contains(@epub:type, 'z3998:roman')])]"</i> <u>src/epub/text/<i class="glob">*</i>.xhtml</u></code>
 					</li>
 					<li>
 						<p>Sometimes <code class="bash"><b>se</b> typogrify</code> doesn’t close quotation marks near em-dashes correctly.</p>


### PR DESCRIPTION
1. In the producer guide, provide the `xpath` command from the reviewer guide to find instances of all-caps instead of the current regex. Not only is the xpath command easier to use (just paste it in), it covers more edge cases, so I don't see why producers shouldn't use it too.
2. In the reviewer guide, add a reminder to `lint` at the start of the review. I figure most reviewers do this anyways, but it's good to have an explicit reminder so you don't forget. Otherwise you'll get all the way to the bottom before the guide tells you to lint, if you forgot to do that at the start.