### PR TITLE
Remove PollItem property from Session

### DIFF
--- a/lib/Session.php
+++ b/lib/Session.php
@@ -4,7 +4,6 @@ use Safe\DateTime;
 
 /**
  * @property User $User
- * @property PollItem $PollItem
  * @property string $Url
  */
 class Session extends PropertiesBase{


### PR DESCRIPTION
I think this was a copy–paste error when the file was created in 0bc3dc3 with Session.php based on PollVote.php.