### PR TITLE
Payments is missing IsMatchingDonation

### DIFF
--- a/config/sql/se/Payments.sql
+++ b/config/sql/se/Payments.sql
@@ -7,6 +7,7 @@ CREATE TABLE `Payments` (
   `Amount` decimal(7,2) unsigned NOT NULL,
   `Fee` decimal(7,2) unsigned NOT NULL DEFAULT 0.00,
   `IsRecurring` tinyint(1) unsigned NOT NULL,
+  `IsMatchingDonation` tinyint(1) unsigned NOT NULL,
   PRIMARY KEY (`PaymentId`),
   KEY `index2` (`UserId`,`Amount`,`Created`,`IsRecurring`)
 ) ENGINE=InnoDB AUTO_INCREMENT=828 DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
When visiting `/about`, I get this error:

```
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'IsMatchingDonation' in 'where clause' in /standardebooks.org/web/lib/DbConnection.php:89"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "Stack trace:"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "#0 /standardebooks.org/web/lib/DbConnection.php(89): PDO->prepare()"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "#1 /standardebooks.org/web/lib/Db.php(45): DbConnection->Query()"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "#2 /standardebooks.org/web/www/about/index.php(19): Db::QueryInt()"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "#3 {main}"
[17-Jun-2023 12:24:11] WARNING: [pool standardebooks.test] child 26536 said into stderr: "  thrown in /standardebooks.org/web/lib/DbConnection.php on line 89"
```

I think it's because e7ef78b added `IsMatchingDonation` to the code, but not to `config/sql/se/Payments.sql`.

This PR solves the problem, but you may have a similar change locally, too.