### PR TITLE
Add Get() method to Artist

### DIFF
--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -21,6 +21,27 @@ class Artist extends PropertiesBase{
 			throw $error;
 		}
 	}
+	// ***********
+	// ORM METHODS
+	// ***********
+
+	public static function Get(?int $artistId): Artist{
+		if($artistId === null){
+			throw new Exceptions\InvalidArtistException();
+		}
+
+		$result = Db::Query('
+				SELECT *
+				from Artists
+				where ArtistId = ?
+			', [$artistId], 'Artist');
+
+		if(sizeof($result) == 0){
+			throw new Exceptions\InvalidArtistException();
+		}
+
+		return $result[0];
+	}
 
 	public function Create(): void{
 		$this->Validate();

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -9,6 +9,7 @@ use Safe\DateTime;
 class Artwork extends PropertiesBase{
 	public $Name;
 	public $ArtworkId;
+	public $ArtistId;
 	public $CompletedYear;
 	public $ImageFilesystemPath;
 	public $Created;
@@ -46,25 +47,6 @@ class Artwork extends PropertiesBase{
 		}
 
 		return $this->_ArtworkTags;
-	}
-
-	/**
-	 * @return Artist
-	 */
-	protected function GetArtist(): Artist{
-		if($this->_Artist === null){
-			$result = Db::Query('
-					SELECT *
-					from Artists
-					where ArtistId = ?
-				', [$this->_Artist->ArtistId], 'Artist');
-			if(sizeof($result) == 0){
-				throw new Exceptions\InvalidArtistException();
-			}
-			$this->_Artist = $result[0];
-		}
-
-		return $this->_Artist;
 	}
 
 	// *******


### PR DESCRIPTION
Hi Job, I'm working on this admin page:

* `GET <root>/admin/artworks` -- view the queue of unapproved artwork

and I realized I made a mistake on the `Get()` function for `Artist.php`. I tested this PR locally and the `PropertiesBase` syntactic sugar does the right thing this way.

I peeked at your in progress PR #236, and this change doesn't look like it will conflict with yours. (Thanks for fixing some mistakes in `Artwork.php`, like adding `CompletedYearIsCirca`.)

Would you mind giving me a quick review before I merge?

cc: @jobcurtis 
Progress on #234 