### PR TITLE
Artwork review queue for admins

### DIFF
--- a/config/apache/standardebooks.org.conf
+++ b/config/apache/standardebooks.org.conf
@@ -295,6 +295,13 @@ Define webroot /standardebooks.org/web
 	RewriteRule 				^/bulk-downloads/(.+\.zip)$			/bulk-downloads/download.php?path=$1
 	RewriteRule 				^/bulk-downloads/([^/\.]+)$			/bulk-downloads/collection.php?class=$1
 
+	# Rewrite rules for cover art
+	RewriteCond expr "tolower(%{REQUEST_METHOD}) =~ /^get$/"
+	RewriteRule				^/admin/artworks/([^/\.]+)$			/admin/artworks/get.php?artworkid=$1 [L]
+
+	RewriteCond expr "tolower(%{REQUEST_METHOD}) =~ /^post$/"
+	RewriteRule				^/admin/artworks/([^/\.]+)$			/admin/artworks/post.php?artworkid=$1 [L]
+
 	# Specific config for /bulk-downloads
 	<DirectoryMatch "${webroot}/www/bulk-downloads">
 		# Both directives are required

--- a/config/apache/standardebooks.test.conf
+++ b/config/apache/standardebooks.test.conf
@@ -277,6 +277,13 @@ Define webroot /standardebooks.org/web
 	RewriteRule 				^/bulk-downloads/(.+\.zip)$			/bulk-downloads/download.php?path=$1
 	RewriteRule 				^/bulk-downloads/([^/\.]+)$			/bulk-downloads/collection.php?class=$1
 
+	# Rewrite rules for cover art
+	RewriteCond expr "tolower(%{REQUEST_METHOD}) =~ /^get$/"
+	RewriteRule				^/admin/artworks/([^/\.]+)$			/admin/artworks/get.php?artworkid=$1 [L]
+
+	RewriteCond expr "tolower(%{REQUEST_METHOD}) =~ /^post$/"
+	RewriteRule				^/admin/artworks/([^/\.]+)$			/admin/artworks/post.php?artworkid=$1 [L]
+
 	# Specific config for /bulk-downloads
 	<DirectoryMatch "${webroot}/www/bulk-downloads">
 		# Both directives are required

--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -12,5 +12,6 @@ CREATE TABLE `Artworks` (
   `PublicationYearPage` varchar(255) NULL,
   `CopyrightPage` varchar(255) NULL,
   `ArtworkPage` varchar(255) NULL,
-  PRIMARY KEY (`ArtworkId`)
+  PRIMARY KEY (`ArtworkId`),
+  KEY `index1` (`Status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -130,9 +130,31 @@ class Artwork extends PropertiesBase{
 		}
 	}
 
-    /**
-     * @throws \Exceptions\ValidationException
-     */
+	// ***********
+	// ORM METHODS
+	// ***********
+
+	public static function Get(?int $artworkId): Artwork{
+		if($artworkId === null){
+			throw new Exceptions\InvalidArtworkException();
+		}
+
+		$result = Db::Query('
+				SELECT *
+				from Artworks
+				where ArtworkId = ?
+			', [$artworkId], 'Artwork');
+
+		if(sizeof($result) == 0){
+			throw new Exceptions\InvalidArtworkException();
+		}
+
+		return $result[0];
+	}
+
+	/**
+	 * @throws \Exceptions\ValidationException
+	 */
 	public function Create(): void{
 		$this->Validate();
 		$this->Created = new DateTime();
@@ -166,6 +188,19 @@ class Artwork extends PropertiesBase{
 				', [$this->ArtworkId, $this->ArtworkTags[$i]->TagId]);
 			}
 		}
+	}
+
+	/**
+	 * @throws \Exceptions\ValidationException
+	 */
+	public function Save(): void{
+		$this->Validate();
+
+		Db::Query('
+			UPDATE Artworks
+			set Status = ?
+			where ArtworkId = ?
+		', [$this->Status, $this->ArtworkId]);
 	}
 
 	public function Delete(): void{

--- a/templates/AdminArtworkList.php
+++ b/templates/AdminArtworkList.php
@@ -1,0 +1,20 @@
+<?
+
+$artworks = $artworks ?? [];
+?>
+<ol class="artwork-list list">
+<? foreach($artworks as $artwork){ ?>
+	<li>
+		<div class="thumbnail-container">
+			<picture>
+				<a href="/admin/artworks/<?= $artwork->ArtworkId ?>"><img src="<?= $artwork->ThumbUrl ?>" property="schema:image"/></a>
+			</picture>
+		</div>
+		<p>Title: <a href="/admin/artworks/<?= $artwork->ArtworkId ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
+		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
+		<div>
+			<p>Year completed: <?= $artwork->CompletedYear ?></p>
+		</div>
+	</li>
+<? } ?>
+</ol>

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -4,9 +4,9 @@
 </picture>
 <h2>Metadata</h2>
 <p>Title: <?= Formatter::ToPlainText($artwork->Name) ?></p>
-<p>Artist: <?= Formatter::ToPlainText($artwork->Artist->Name) ?></p>
+<p>Artist: <?= Formatter::ToPlainText($artwork->Artist->Name) ?>, Death Year: <?= $artwork->Artist->DeathYear ?></p>
 <p>Completed Year: <?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?></p>
-<p>Uploaded: <?= $artwork->Created->format('c') ?></p>
+<p>Uploaded: <?= $artwork->Created->format('F j, Y g:i a') ?></p>
 <p>Status: <?= Formatter::ToPlainText($artwork->Status) ?></p>
 <p>Tags:</p>
 <ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul>
@@ -16,7 +16,7 @@
 	<ul>
 		<li>Link to an approved museum page</li>
 	</ul>
-	<p>or <strong>all</strong> of the following:
+	<p>or <strong>all</strong> of the following:</p>
 	<ol>
 		<li>Year book was published</li>
 		<li>Link to direct page scan of artwork (not just the start of the book, the direct page)</li>

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -1,0 +1,37 @@
+<h1><?= Formatter::ToPlainText($artwork->Name) ?></h1>
+<picture>
+	<a href="<?= $artwork->ImageUrl ?>"><img src="<?= $artwork->ThumbUrl ?>" property="schema:image"/></a>
+</picture>
+<h2>Metadata</h2>
+<p>Title: <?= Formatter::ToPlainText($artwork->Name) ?></p>
+<p>Artist: <?= Formatter::ToPlainText($artwork->Artist->Name) ?></p>
+<p>Completed Year: <?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?></p>
+<p>Uploaded: <?= $artwork->Created->format('c') ?></p>
+<p>Status: <?= Formatter::ToPlainText($artwork->Status) ?></p>
+<p>Tags:</p>
+<ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul>
+<h2>PD Proof</h2>
+<aside class="tip">
+	<p>PD proof must take the form of:</p>
+	<ul>
+		<li>Link to an approved museum page</li>
+	</ul>
+	<p>or <strong>all</strong> of the following:
+	<ol>
+		<li>Year book was published</li>
+		<li>Link to direct page scan of artwork (not just the start of the book, the direct page)</li>
+		<li>Link to direct page scan of page mentioning book publication year (not just the start of the book, the direct page)</li>
+		<li>Link to direct page scan of book copyright/rights statement page (may be the same as the publication year page but not always)</li>
+	</ol>
+</aside>
+<h3>Museum page</h3>
+<ul>
+	<li>Link to an approved museum page: <? if($artwork->MuseumPage !== null){ ?> <a href="<?= Formatter::ToPlainText($artwork->MuseumPage) ?>">Link</a><? }else{ ?>(not provided)<? } ?></li>
+</ul>
+<h3>Links to scans</h3>
+<ol>
+	<li>Year book was published: <? if($artwork->PublicationYear !== null){ ?><?= $artwork->PublicationYear ?><? }else{ ?>(not provided)<? } ?></li>
+	<li>Link to direct page scan of artwork: <? if($artwork->ArtworkPage !== null){ ?><a href="<?= Formatter::ToPlainText($artwork->ArtworkPage) ?>">Link</a><? }else{ ?>(not provided)<? } ?></li>
+	<li>Link to direct page scan of page mentioning book publication year: <? if($artwork->PublicationYearPage !== null){ ?><a href="<?= Formatter::ToPlainText($artwork->PublicationYearPage) ?>">Link</a><? }else{ ?>(not provided)<? } ?></li>
+	<li>Link to direct page scan of book copyright/rights statement page: <? if($artwork->CopyrightPage !== null){ ?><a href="<?= Formatter::ToPlainText($artwork->CopyrightPage) ?>">Link</a><? }else{ ?>(not provided)<? } ?></li>
+</ol>

--- a/www/admin/artworks/get.php
+++ b/www/admin/artworks/get.php
@@ -1,0 +1,26 @@
+<?
+require_once('Core.php');
+
+$artworkId = HttpInput::Int(GET, 'artworkid');
+
+try{
+	$artwork = Artwork::Get($artworkId);
+}
+catch(Exceptions\SeException $ex){
+	Template::Emit404();
+}
+
+?><?= Template::Header(['title' => 'Review Artwork', 'highlight' => '', 'description' => 'Unapproved artwork.']) ?>
+<main class="artworks">
+	<section>
+		<?= Template::ArtworkDetail(['artwork' => $artwork]) ?>
+	</section>
+	<h2>Review</h2>
+	<p>Review the metadata and PD proof for this artwork submission. Approve to make it available for future producers.<p>
+	<form method="post" action="/admin/artworks/<?= $artwork->ArtworkId ?>">
+		<input type="hidden" name="_method" value="PATCH">
+		<button name="status" value="approved">Approve</button>
+		<button name="status" value="declined" class="decline-button">Decline</button>
+	</form>
+</main>
+<?= Template::Footer() ?>

--- a/www/admin/artworks/get.php
+++ b/www/admin/artworks/get.php
@@ -16,9 +16,9 @@ catch(Exceptions\SeException $ex){
 		<?= Template::ArtworkDetail(['artwork' => $artwork]) ?>
 	</section>
 	<h2>Review</h2>
-	<p>Review the metadata and PD proof for this artwork submission. Approve to make it available for future producers.<p>
+	<p>Review the metadata and PD proof for this artwork submission. Approve to make it available for future producers.</p>
 	<form method="post" action="/admin/artworks/<?= $artwork->ArtworkId ?>">
-		<input type="hidden" name="_method" value="PATCH">
+		<input type="hidden" name="_method" value="PATCH" />
 		<button name="status" value="approved">Approve</button>
 		<button name="status" value="declined" class="decline-button">Decline</button>
 	</form>

--- a/www/admin/artworks/index.php
+++ b/www/admin/artworks/index.php
@@ -1,0 +1,70 @@
+<?
+require_once('Core.php');
+
+session_start();
+
+$approvedMessage = $_SESSION['approved-message'] ?? null;
+$declinedMessage = $_SESSION['declined-message'] ?? null;
+
+if ($approvedMessage || $declinedMessage){
+	http_response_code(201);
+	session_unset();
+}
+
+$page = HttpInput::Int(GET, 'page') ?? 1;
+if($page <= 0){
+	$page = 1;
+}
+$perPage = 10;
+
+$unverifiedArtworks = Db::Query('
+				SELECT *
+				from Artworks
+				where status = "unverified"
+				order by Created asc
+			', [], 'Artwork');
+$count = sizeof($unverifiedArtworks);
+$pages = ceil($count / $perPage);
+
+$unverifiedArtworks = array_slice($unverifiedArtworks, ($page - 1) * $perPage, $perPage);
+
+?><?= Template::Header(['title' => 'Review Artwork Queue', 'highlight' => '', 'description' => 'The queue of unapproved artwork.']) ?>
+<main class="artworks">
+	<section class="narrow">
+		<hgroup>
+			<h1>Review Artwork Queue</h1>
+		</hgroup>
+
+		<section id="unapproved-artwork">
+			<? if ($approvedMessage){ ?>
+			<p class="message success">
+				<?= $approvedMessage ?>
+			</p>
+			<? } ?>
+			<? if ($declinedMessage){ ?>
+			<p class="message">
+				<?= $declinedMessage ?>
+			</p>
+			<? } ?>
+			<? if($count > 0){ ?>
+			<?= Template::AdminArtworkList(['artworks' => $unverifiedArtworks]) ?>
+			<? }else{ ?>
+			<p>No artwork to review.</p>
+			<? } ?>
+		</section>
+	</section>
+
+	<? if($count > 0){ ?>
+	<nav>
+		<a<? if($page > 1){ ?> href="/admin/artworks/?page=<?= $page - 1 ?>" rel="prev"<? }else{ ?> aria-disabled="true"<? } ?>>Back</a>
+		<ol>
+		<? for($i = 1; $i < $pages + 1; $i++){ ?>
+			<li<? if($page == $i){ ?> class="highlighted"<? } ?>><a href="/admin/artworks/?page=<?= $i ?>"><?= $i ?></a></li>
+		<? } ?>
+		</ol>
+		<a<? if($page < ceil($count / $perPage)){ ?> href="/admin/artworks/?page=<?= $page + 1 ?>" rel="next"<? }else{ ?> aria-disabled="true"<? } ?>>Next</a>
+	</nav>
+	<? } ?>
+
+</main>
+<?= Template::Footer() ?>

--- a/www/admin/artworks/post.php
+++ b/www/admin/artworks/post.php
@@ -1,0 +1,40 @@
+<?
+require_once('Core.php');
+
+if(HttpInput::RequestMethod() != HTTP_PATCH){
+	http_response_code(405);
+	exit();
+}
+
+$artworkId = HttpInput::Int(GET, 'artworkid');
+
+try{
+	$artwork = Artwork::Get($artworkId);
+}
+catch(Exceptions\SeException $ex){
+	Template::Emit404();
+}
+
+session_start();
+
+try{
+	$newStatus = HttpInput::Str(POST, 'status');
+	switch($newStatus){
+		case 'approved':
+			$artwork->Status = 'approved';
+			$_SESSION['approved-message'] = '“' . $artwork->Name . '” approved.';
+			break;
+		case 'declined':
+			$artwork->Status = 'declined';
+			$_SESSION['declined-message'] = '“' . $artwork->Name . '” declined.';
+			break;
+	}
+
+	$artwork->Save();
+
+	http_response_code(303);
+	header('Location: /admin/artworks');
+}
+catch(Exceptions\SeException $ex){
+	http_response_code(422);
+}

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -641,7 +641,16 @@ h1 + section > h2:first-child{
 
 }
 
+form button.decline-button{
+	background-color: #777;
+}
+
+form button.decline-button:hover{
+	background-color: #aaa;
+}
+
 a.button,
+.artworks nav > a,
 .ebooks nav > a,
 form button{
 	border: 1px solid rgba(0, 0, 0, .5);
@@ -679,6 +688,7 @@ h1 + .message{
 }
 
 .message{
+	background: rgba(0, 0, 0, .2);
 	border: 2px solid rgba(0, 0, 0, .25);
 	border-radius: .25rem;
 	padding: 1rem;
@@ -814,6 +824,7 @@ h2 + .download-list tr.year-header:first-child th{
 	text-align: center;
 }
 
+.artworks nav li.highlighted a:focus,
 .ebooks nav li.highlighted a:focus,
 a.button:focus,
 input[type="email"]:focus,
@@ -836,6 +847,7 @@ select::-moz-focus-inner{
 }
 
 a.button:active,
+.artworks nav > a[href]:active,
 .ebooks nav > a[href]:active,
 form button:active{
 	top: 2px;
@@ -844,6 +856,7 @@ form button:active{
 }
 
 a.button.next::after,
+.artworks nav > a:last-child::after,
 .ebooks nav > a:last-child::after{
 	font-family: "Fork Awesome";
 	content: "\f061";
@@ -854,12 +867,14 @@ a.button.next::after,
 }
 
 a[href].button.next:hover::after,
+.artworks nav > a:last-child[href]:hover::after,
 .ebooks nav > a:last-child[href]:hover::after{
 	left: .25rem;
 	position: relative;
 	transition: all 200ms ease;
 }
 
+.artworks nav > a:first-child:before,
 .ebooks nav > a:first-child:before{
 	font-family: "Fork Awesome";
 	content: "\f060";
@@ -869,6 +884,7 @@ a[href].button.next:hover::after,
 	margin-right: .5rem;
 }
 
+.artworks nav > a:first-child[href]:hover::before,
 .ebooks nav > a:first-child[href]:hover::before{
 	right: .25rem;
 	position: relative;
@@ -876,6 +892,7 @@ a[href].button.next:hover::after,
 }
 
 a.button.next:hover::after,
+.artworks nav > a:last-child[href]:hover::after,
 .ebooks nav > a:last-child[href]:hover::after{
 	left: .25rem;
 	position: relative;
@@ -883,14 +900,18 @@ a.button.next:hover::after,
 }
 
 article nav ol li a:hover,
+main.artworks nav ol li a:hover,
+main.artworks nav ol li.highlighted a:hover,
 main.ebooks nav ol li a:hover,
 main.ebooks nav ol li.highlighted a:hover,
 a.button:hover,
+.artworks nav > a:hover,
 .ebooks nav > a:hover,
 form button:hover{
 	background-color: var(--button-highlight);
 }
 
+.artworks nav > a:not([href]),
 .ebooks nav > a:not([href]){
 	cursor: default;
 	color: #efefef;
@@ -1512,7 +1533,58 @@ ol.ebooks-list > li p.author a{
 	justify-content: center;
 }
 
+ol.artwork-list.list{
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	margin-bottom: 4rem;
+	margin-left: auto;
+	margin-right: auto;
+	width: 100%;
+	max-width: 30rem;
+}
+
+ol.artwork-list.list > li{
+	display: grid;
+	grid-template-columns: 6rem 1fr;
+	grid-column-gap: 1rem;
+	grid-template-rows: auto auto 1fr;
+}
+
+ol.artwork-list.list > li + li {
+	margin-top: 2rem;
+}
+
+ol.artwork-list.list > li .thumbnail-container{
+	grid-row: 1 / span 3;
+}
+
+ol.artwork-list.list > li p{
+	text-align: left;
+}
+
+ol.artwork-list > li p{
+	margin: 0;
+}
+
+ol.artwork-list > li img{
+	box-sizing: border-box;
+	max-width: 100%;
+	height: auto;
+	border: 1px solid var(--border);
+	border-radius: .25rem;
+}
+
+ol.artwork-list > li > p:nth-of-type(1) > span{
+	font-weight: bold;
+}
+
+ol.artwork-list > li .author{
+	font-style: italic;
+}
+
 article nav ol,
+main.artworks nav ol,
 main.ebooks nav ol{
 	list-style: none;
 	display: flex;
@@ -1623,6 +1695,7 @@ figure p + p{
 	margin-top: 15px;
 }
 
+main.artworks nav,
 main.ebooks nav{
 	display: flex;
 	justify-content: center;
@@ -1631,12 +1704,14 @@ main.ebooks nav{
 }
 
 article nav ol li,
+main.artworks nav ol li,
 main.ebooks nav ol li{
 	margin: 0;
 	white-space: nowrap;
 }
 
 article nav ol li a,
+main.artworks nav ol li a,
 main.ebooks nav ol li a{
 	font-size: 1rem;
 	line-height: 1.4;
@@ -1650,14 +1725,17 @@ main.ebooks nav ol li a{
 }
 
 article nav ol li.highlighted a,
+main.artworks nav ol li.highlighted a,
 main.ebooks nav ol li.highlighted a{
 	background: var(--button);
 	border: 1px solid rgba(0, 0, 0, .5);
 }
 
 article nav ol li.highlighted a,
+main.artworks nav ol li.highlighted a,
 main.ebooks nav ol li.highlighted a,
 article nav ol li a:hover,
+main.artworks nav ol li a:hover,
 main.ebooks nav ol li a:hover{
 	color: #fff;
 	text-decoration: none;
@@ -1975,17 +2053,20 @@ form.single-row button{
 }
 
 article nav ol li:not(:first-child):not(:last-child):not(.highlighted),
+main.artworks nav ol li:not(:first-child):not(:last-child):not(.highlighted),
 main.ebooks nav ol li:not(:first-child):not(:last-child):not(.highlighted){
 	display: none;
 }
 
 article nav ol li.highlighted::before,
+main.artworks nav ol li.highlighted::before,
 main.ebooks nav ol li.highlighted::before{
 	content: "⋯";
 	padding-right: 1rem;
 }
 
 article nav ol li.highlighted::after,
+main.artworks nav ol li.highlighted::after,
 main.ebooks nav ol li.highlighted::after{
 	content: "⋯";
 	padding-left: 1rem;
@@ -1995,6 +2076,10 @@ article nav ol li.highlighted:first-child::before,
 article nav ol li.highlighted:last-child::after,
 article nav ol li.highlighted:nth-child(2)::before,
 article nav ol li.highlighted:nth-last-child(2)::after,
+main.artworks nav ol li.highlighted:first-child::before,
+main.artworks nav ol li.highlighted:last-child::after,
+main.artworks nav ol li.highlighted:nth-child(2)::before,
+main.artworks nav ol li.highlighted:nth-last-child(2)::after,
 main.ebooks nav ol li.highlighted:first-child::before,
 main.ebooks nav ol li.highlighted:last-child::after,
 main.ebooks nav ol li.highlighted:nth-child(2)::before,
@@ -2862,6 +2947,41 @@ ul.feed p{
 	padding-bottom: 0;
 }
 
+.artworks picture{
+	text-align: center;
+}
+
+.artworks aside.tip{
+	font-style: italic;
+	margin: 1rem 0;
+	position: relative;
+	padding: 1rem;
+	padding-left: 2rem;
+	padding-top: 2rem;
+	background: rgba(0, 0, 0, .2);
+}
+
+.artworks aside.tip::before{
+	font-family: "Fork Awesome";
+	content: "\f0eb";
+	font-size: 1rem;
+	position: absolute;
+	font-style: normal;
+	left: .75rem;
+	top: .25rem;
+}
+
+.artworks aside.tip::after{
+	content: "Tip";
+	font-family: "League Spartan";
+	text-transform: uppercase;
+	font-size: .75rem;
+	position: absolute;
+	font-style: normal;
+	left: 2rem;
+	top: .5rem;
+}
+
 @media (hover: none) and (pointer: coarse){ /* target ipads and smartphones without a mouse */
 	/* For iPad, unset the height so it matches the other elements */
 	select[multiple]{
@@ -3151,6 +3271,7 @@ ul.feed p{
 	}
 
 	article nav ol li:not(.highlighted),
+	main.artwork nav ol li:not(.highlighted),
 	main.ebooks nav ol li:not(.highlighted){
 		display: none;
 	}
@@ -3193,6 +3314,8 @@ ul.feed p{
 
 	article nav ol li.highlighted::before,
 	article nav ol li.highlighted::after,
+	main.artworks nav ol li.highlighted::before,
+	main.artworks nav ol li.highlighted::after,
 	main.ebooks nav ol li.highlighted::before,
 	main.ebooks nav ol li.highlighted::after{
 		display: none;
@@ -3313,6 +3436,7 @@ ul.feed p{
 		margin-bottom: .5rem;
 	}
 
+	main.artworks nav,
 	main.ebooks nav{
 		margin-top: .5rem;
 	}
@@ -3351,11 +3475,14 @@ ul.feed p{
 	}
 
 	article nav a[rel],
+	main.artworks nav > a,
 	main.ebooks nav > a{
 		margin-bottom: 0;
 		font-size: 0;
 	}
 
+	main.artworks nav > a::before,
+	main.artworks nav > a::after,
 	main.ebooks nav > a::before,
 	main.ebooks nav > a::after {
 		font-size: 1rem;
@@ -3363,8 +3490,10 @@ ul.feed p{
 	}
 
 	article nav a[rel]::before,
+	main.artworks nav a[rel]::before,
 	main.ebooks nav a[rel]::before,
 	article nav a[rel]::after,
+	main.artworks nav a[rel]::after,
 	main.ebooks nav a[rel]::after{
 		font-size: 1rem;
 		margin: 0;
@@ -3523,6 +3652,7 @@ ul.feed p{
 	}
 
 	article nav a[rel],
+	main.artworks nav > a,
 	main.ebooks nav > a{
 		padding: 1rem;
 	}
@@ -3560,12 +3690,17 @@ ul.feed p{
 	header nav li a:hover,
 	header nav li a[aria-current]:hover,
 	a.button.next::after,
+	.artworks nav > a:last-child::after,
 	.ebooks nav > a:last-child::after,
 	a[href].button.next:hover::after,
+	.artworks nav > a:last-child[href]:hover::after,
+	.artworks nav > a:first-child:before,
+	.artworks nav > a:first-child[href]:hover::before,
 	.ebooks nav > a:last-child[href]:hover::after,
 	.ebooks nav > a:first-child:before,
 	.ebooks nav > a:first-child[href]:hover::before,
 	a.button.next:hover::after,
+	.artworks nav > a:last-child[href]:hover::after,
 	.ebooks nav > a:last-child[href]:hover::after,
 	article.ebook section#read-online a::before,
 	article.ebook section#download ul li a[class]::before,


### PR DESCRIPTION
Hi @jobcurtis, here's a PR for you to try out and review. You'll need to use your form from #236 to submit some artwork, then visit:

```
/admin/artworks
```

to review them. After you've reviewed them, you can set your artwork records back to `unverified` in MySQL with:

```
MariaDB [se]> UPDATE Artworks SET Status = 'unverified' WHERE ArtworkId IS NOT NULL;
```

so that you can review them again.

This PR handles these two URLs:

* `GET <root>/admin/artworks` -- view the queue of unapproved artwork
* `POST <root>/admin/artworks/<artwork-id>` -- approve or reject artwork with status=<approved,declined>. Restfully this would be a PATCH request

One future TODO we'll have to note on #234 (in addition to any large issue you find): I did not yet password-protect the admin page via Apache.