### PR TITLE
Artwork submission form - persist fields when submission fails

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -4,6 +4,7 @@ use Safe\DateTime;
 /**
  * @property string $UrlName
  * @property array<ArtworkTag> $ArtworkTags
+ * @property string $ArtworkTagsImploded
  * @property Artist $Artist
  * @property string $ImageUrl
  * @property string $ThumbUrl
@@ -57,6 +58,12 @@ class Artwork extends PropertiesBase{
 		}
 
 		return $this->_ArtworkTags;
+	}
+
+	protected function GetArtworkTagsImploded(): string{
+		$tags = $this->ArtworkTags ?? [];
+		$tags = array_column($tags, 'Name');
+		return implode(', ', $tags);
 	}
 
 	/**

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -109,12 +109,7 @@ if ($exception){
 						type="text"
 						name="artwork-tags"
 						placeholder="tags, comma-separated"
-						value="<?php
-							$tags = $artwork->ArtworkTags ?? [];
-							$tags = array_column($tags, 'Name');
-							$tags = implode(', ', $tags);
-							print $tags;
-						?>"
+						value="<?= $artwork->ArtworkTagsImploded ?>"
 					/>
 				</label>
 			</fieldset>

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -3,17 +3,21 @@ require_once('Core.php');
 
 session_start();
 
-$exception = $_SESSION['exception'] ?? null;
-
-if ($exception){
-	http_response_code(422);
-	session_unset();
-}
-
 $successMessage = $_SESSION['success-message'] ?? null;
 
 if ($successMessage){
 	http_response_code(201);
+	session_unset();
+}
+
+/** @var Artwork $artwork */
+$artwork = $_SESSION['artwork'] ?? new Artwork();
+$artist = $artwork->Artist ?? new Artist();
+
+$exception = $_SESSION['exception'] ?? null;
+
+if ($exception){
+	http_response_code(422);
 	session_unset();
 }
 
@@ -47,15 +51,27 @@ if ($successMessage){
 					<label>
 						Artist Name
 						<datalist id="artist-names">
-							<?php foreach (Artist::GetAll() as $artist): ?>
-								<option value="<?= $artist->Name ?>"></option>
+							<?php foreach (Artist::GetAll() as $existingArtist): ?>
+								<option value="<?= $existingArtist->Name ?>"></option>
 							<?php endforeach; ?>
 						</datalist>
-						<input type="text" name="artist-name" list="artist-names" required="required"/>
+						<input
+							type="text"
+							name="artist-name"
+							list="artist-names"
+							required="required"
+							value="<?= $artist->Name ?>"
+						/>
 					</label>
 					<label>
 						Year of Death
-						<input type="number" name="artist-year-of-death" min="0" max="<?= gmdate('Y') ?>"/>
+						<input
+							type="number"
+							name="artist-year-of-death"
+							min="0"
+							max="<?= gmdate('Y') ?>"
+							value="<?= $artist->DeathYear ?>"
+						/>
 					</label>
 				</div>
 			</fieldset>
@@ -64,20 +80,42 @@ if ($successMessage){
 				<div>
 					<label>
 						Artwork Name
-						<input type="text" name="artwork-name" required="required"/>
+						<input type="text" name="artwork-name" required="required"
+						       value="<?= $artwork->Name ?>"/>
 					</label>
 					<label for="artwork-year">
 						Year of Completion
 						<label>
 							(circa?
-							<input type="checkbox" name="artwork-year-is-circa"/>)
+							<input
+								type="checkbox"
+								name="artwork-year-is-circa"
+								value="<?= $artwork->CompletedYearIsCirca ?>"
+							/>)
 						</label>
-						<input type="number" id="artwork-year" name="artwork-year" min="0" max="<?= gmdate('Y') ?>"/>
+						<input
+							type="number"
+							id="artwork-year"
+							name="artwork-year"
+							min="0"
+							max="<?= gmdate('Y') ?>"
+							value="<?= $artwork->CompletedYear ?>"
+						/>
 					</label>
 				</div>
 				<label>
 					Artwork Tags
-					<input type="text" name="artwork-tags" placeholder="tags, comma-separated"/>
+					<input
+						type="text"
+						name="artwork-tags"
+						placeholder="tags, comma-separated"
+						value="<?php
+							$tags = $artwork->ArtworkTags ?? [];
+							$tags = array_column($tags, 'Name');
+							$tags = implode(', ', $tags);
+							print $tags;
+						?>"
+					/>
 				</label>
 			</fieldset>
 			<fieldset id="pd-proof">
@@ -86,25 +124,47 @@ if ($successMessage){
 					<div>
 						<label>
 							Link to page with year of publication
-							<input type="url" name="pd-proof-year-of-publication-page"/>
+							<input
+								type="url"
+								name="pd-proof-year-of-publication-page"
+								value="<?= $artwork->PublicationYearPage ?>"
+							/>
 						</label>
 						<label>
 							Year of publication
-							<input type="number" name="pd-proof-year-of-publication" min="0" max="<?= gmdate('Y') ?>"/>
+							<input
+								type="number"
+								name="pd-proof-year-of-publication"
+								min="0"
+								max="<?= gmdate('Y') ?>"
+								value="<?= $artwork->PublicationYear ?>"
+							/>
 						</label>
 					</div>
 					<label>
 						Link to page with copyright details
-						<input type="url" name="pd-proof-copyright-page"/>
+						<input
+							type="url"
+							name="pd-proof-copyright-page"
+							value="<?= $artwork->CopyrightPage ?>"
+						/>
 					</label>
 					<label>
 						Link to page with artwork
-						<input type="url" name="pd-proof-artwork-page"/>
+						<input
+							type="url"
+							name="pd-proof-artwork-page"
+							value="<?= $artwork->ArtworkPage ?>"
+						/>
 					</label>
 				</fieldset>
 				<label>
 					Link to museum page
-					<input type="url" name="pd-proof-museum-link"/>
+					<input
+						type="url"
+						name="pd-proof-museum-link"
+						value="<?= $artwork->MuseumPage ?>"
+					/>
 				</label>
 			</fieldset>
 			<fieldset>

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -69,10 +69,9 @@ if (HttpInput::RequestMethod() != HTTP_POST){
 session_start();
 
 try{
-	$artistName = HttpInput::Str(POST, 'artist-name', false);
-	$artistYearOfDeath = HttpInput::Int(POST, 'artist-year-of-death');
-
-	$artist = Artist::GetOrCreate($artistName, $artistYearOfDeath);
+	$artist = new Artist();
+	$artist->Name = HttpInput::Str(POST, 'artist-name', false);
+	$artist->DeathYear = HttpInput::Int(POST, 'artist-year-of-death');
 
 	$artwork = new Artwork();
 
@@ -97,6 +96,7 @@ try{
 		throw new Exceptions\InvalidCaptchaException();
 	}
 
+	$artist->GetOrCreate();
 	$artwork->Create();
 
 	handleImageUpload($_FILES['color-upload']['tmp_name'], $artwork);
@@ -119,6 +119,10 @@ try{
 
 		// remove database entry
 		$artwork->Delete();
+	}
+
+	if (isset($artist->ArtistId)){
+		$artist->DeleteIfUnused();
 	}
 
 	http_response_code(303);

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -69,13 +69,6 @@ if (HttpInput::RequestMethod() != HTTP_POST){
 session_start();
 
 try{
-	$expectCaptcha = HttpInput::Str(SESSION, 'captcha', false);
-	$actualCaptcha = HttpInput::Str(POST, 'captcha', false);
-
-	if ($expectCaptcha === '' || mb_strtolower($expectCaptcha) !== mb_strtolower($actualCaptcha)){
-		throw new Exceptions\InvalidCaptchaException();
-	}
-
 	$artistName = HttpInput::Str(POST, 'artist-name', false);
 	$artistYearOfDeath = HttpInput::Int(POST, 'artist-year-of-death');
 
@@ -97,6 +90,13 @@ try{
 	$artwork->CopyrightPage = HttpInput::Str(POST, 'pd-proof-copyright-page', false);
 	$artwork->ArtworkPage = HttpInput::Str(POST, 'pd-proof-artwork-page', false);
 
+	$expectCaptcha = HttpInput::Str(SESSION, 'captcha', false);
+	$actualCaptcha = HttpInput::Str(POST, 'captcha', false);
+
+	if ($expectCaptcha === '' || mb_strtolower($expectCaptcha) !== mb_strtolower($actualCaptcha)){
+		throw new Exceptions\InvalidCaptchaException();
+	}
+
 	$artwork->Create();
 
 	handleImageUpload($_FILES['color-upload']['tmp_name'], $artwork);
@@ -107,6 +107,10 @@ try{
 
 } catch (\Exceptions\SeException $exception){
 	$_SESSION['exception'] = $exception;
+
+	if (isset($artwork)){
+		$_SESSION['artwork'] = $artwork;
+	}
 
 	if (isset($artwork->ArtworkId)){
 		// clean up the uploaded file(s)


### PR DESCRIPTION
Hey @colagrosso, here's a few small improvements to the artwork submission form, if you wouldn't mind having a look.

The first is that filled-in fields are persisted after failing validation. The second is less visible, but we're now cleaning up newly-created artists if validation fails for whatever reason. Together these changes required some changes to the order in which objects are created / captchas are checked, etc.