### PR TITLE
In use artwork: Style differently and link to ebook

### DIFF
--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -12,6 +12,7 @@ CREATE TABLE `Artworks` (
   `PublicationYearPage` varchar(255) NULL,
   `CopyrightPage` varchar(255) NULL,
   `ArtworkPage` varchar(255) NULL,
+  `EbookWwwFilesystemPath` varchar(255) NULL,
   PRIMARY KEY (`ArtworkId`),
   KEY `index1` (`Status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -11,6 +11,7 @@ use function Safe\filesize;
  * @property string $ImageUrl
  * @property string $ThumbUrl
  * @property string $ImageSize
+ * @property Ebook $Ebook
  */
 class Artwork extends PropertiesBase{
 	public $Name;
@@ -20,6 +21,7 @@ class Artwork extends PropertiesBase{
 	public $CompletedYearIsCirca;
 	public $Created;
 	public $Status;
+	public $EbookWwwFilesystemPath;
 	protected $_UrlName;
 	protected $_Slug;
 	protected $_ArtworkTags = null;
@@ -27,6 +29,7 @@ class Artwork extends PropertiesBase{
 	protected $_ImageUrl = null;
 	protected $_ThumbUrl = null;
 	protected $_ImageSize = null;
+	protected $_Ebook = null;
 
 	public $MuseumPage;
 	public $PublicationYear;
@@ -130,6 +133,19 @@ class Artwork extends PropertiesBase{
 		}
 
 		return $this->_ImageSize;
+	}
+
+	protected function GetEbook(): Ebook{
+		$this->_Ebook = new Ebook();
+		if ($this->EbookWwwFilesystemPath !== null){
+			try{
+				$this->_Ebook = apcu_fetch('ebook-' . $this->EbookWwwFilesystemPath);
+			}
+			catch(Safe\Exceptions\ApcuException $ex){
+				// The Ebook with that filesystem path isn't cached.
+			}
+		}
+		return $this->_Ebook;
 	}
 
 	// *******

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -28,7 +28,7 @@
 	</tr>
 	<tr>
 		<td>Status</td>
-		<td><? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a><? }else{ ?><?= Formatter::ToPlainText($artwork->Status) ?><? } ?></td>
+		<td><?= Template::ArtworkStatus(['artwork' => $artwork]) ?></td>
 	</tr>
 	<tr>
 		<td>Tags</td>

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -28,7 +28,7 @@
 	</tr>
 	<tr>
 		<td>Status</td>
-		<td><?= Formatter::ToPlainText($artwork->Status) ?></td>
+		<td><? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a><? }else{ ?><?= Formatter::ToPlainText($artwork->Status) ?><? } ?></td>
 	</tr>
 	<tr>
 		<td>Tags</td>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -4,7 +4,7 @@ $artworks = $artworks ?? [];
 ?>
 <ol class="artwork-list list">
 <? foreach($artworks as $artwork){ ?>
-	<li>
+	<li class="<?= $artwork->Status ?>">
 		<div class="thumbnail-container">
 			<a href="/artworks/<?= $artwork->Slug ?>">
 				<picture>
@@ -16,6 +16,7 @@ $artworks = $artworks ?? [];
 		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
+			<p>Status: <? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <? } ?></p>
 			<? if(count($artwork->ArtworkTags) > 0){ ?>
 			<p>Tags: <ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul></p>
 			<? } ?>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -16,7 +16,7 @@ $artworks = $artworks ?? [];
 		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
-			<p>Status: <? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <? } ?></p>
+			<p>Status: <? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a><? } ?></p>
 			<? if(count($artwork->ArtworkTags) > 0){ ?>
 			<p>Tags: <ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul></p>
 			<? } ?>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -16,7 +16,7 @@ $artworks = $artworks ?? [];
 		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
-			<p>Status: <? if($artwork->Status === "approved"){ ?>Approved<? }else if($artwork->Status === "in_use"){ ?>In use by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a><? } ?></p>
+			<p>Status: <?= Template::ArtworkStatus(['artwork' => $artwork]) ?></p>
 			<? if(count($artwork->ArtworkTags) > 0){ ?>
 			<p>Tags: <ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul></p>
 			<? } ?>

--- a/templates/ArtworkStatus.php
+++ b/templates/ArtworkStatus.php
@@ -1,0 +1,16 @@
+<?
+
+$artwork = $artwork ?? null;
+?>
+<? if($artwork !== null){ ?>
+	<? if($artwork->Status === "approved"){ ?>
+		Approved
+	<? }else if($artwork->Status === "in_use"){ ?>
+		In use
+		<? if($artwork->Ebook !== null && $artwork->Ebook->Url !== null){ ?>
+			 by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a>
+		<? } ?>
+	<? }else{ ?>
+		<?= Formatter::ToPlainText($artwork->Status) ?>
+	<? } ?>
+<? } ?>

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1545,14 +1545,21 @@ ol.artwork-list.list{
 }
 
 ol.artwork-list.list > li{
+	border-radius: .25rem;
 	display: grid;
 	grid-template-columns: 16rem 1fr;
 	grid-column-gap: 2rem;
 	grid-template-rows: auto auto 1fr;
+	padding: 1rem;
+}
+
+ol.artwork-list.list > li.in_use{
+	background-color: rgba(0, 0, 0, .2);
+	background-image: url("/images/stripes.svg");
 }
 
 ol.artwork-list.list > li + li {
-	margin-top: 2rem;
+	margin-top: 1rem;
 }
 
 ol.artwork-list.list > li .thumbnail-container{


### PR DESCRIPTION
Check this out, @jobcurtis:

![Screenshot 2023-07-04 1 36 59 AM](https://github.com/standardebooks/web/assets/136965/45ff74ae-e699-4ac1-9162-69cbee5fbaa7)

For artwork that is `in_use`, we style it differently, and it has a link to the ebook the artwork is used in.

If you'd like to modify your `Artworks` table in place and not drop and recreate it, you can run:
```sql
MariaDB [se]> ALTER TABLE Artworks ADD COLUMN EbookWwwFilesystemPath varchar(255) NULL AFTER ArtworkPage;
```

Progress on #234 