### PR TITLE
Replace APCu with DB queries

### DIFF
--- a/config/sql/se/Artists.sql
+++ b/config/sql/se/Artists.sql
@@ -1,6 +1,7 @@
 CREATE TABLE `Artists` (
   `ArtistId` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Name` varchar(191) NOT NULL,
+  `UrlName` varchar(255) NOT NULL,
   `DeathYear` smallint unsigned NULL,
   PRIMARY KEY (`ArtistId`),
   UNIQUE KEY `idxUnique` (`Name`,`DeathYear`)

--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -2,6 +2,7 @@ CREATE TABLE `Artworks` (
   `ArtworkId` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ArtistId` int(10) unsigned NOT NULL,
   `Name` varchar(255) NOT NULL,
+  `UrlName` varchar(255) NOT NULL,
   `CompletedYear` smallint unsigned NULL,
   `CompletedYearIsCirca` boolean NOT NULL DEFAULT FALSE,
   `Created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -13,5 +13,6 @@ CREATE TABLE `Artworks` (
   `CopyrightPage` varchar(255) NULL,
   `ArtworkPage` varchar(255) NULL,
   PRIMARY KEY (`ArtworkId`),
-  KEY `index1` (`Status`)
+  KEY `index1` (`Status`),
+  KEY `index2` (`UrlName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -36,6 +36,10 @@ class Artist extends PropertiesBase{
 			$error->Add(new Exceptions\InvalidArtistException());
 		}
 
+		if($this->UrlName === null || strlen($this->UrlName) === 0){
+			$error->Add(new Exceptions\InvalidArtistException());
+		}
+
 		if($error->HasExceptions){
 			throw $error;
 		}
@@ -65,10 +69,11 @@ class Artist extends PropertiesBase{
 	public function Create(): void{
 		$this->Validate();
 		Db::Query('
-			INSERT into Artists (Name, DeathYear)
-			values (?,
+			INSERT into Artists (Name, UrlName, DeathYear)
+			VALUES (?,
+			        ?,
 			        ?)
-		', [$this->Name, $this->DeathYear]);
+		', [$this->Name, $this->UrlName, $this->DeathYear]);
 
 		$this->ArtistId = Db::GetLastInsertedId();
 	}

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -202,7 +202,7 @@ class Artwork extends PropertiesBase{
 		$this->Validate();
 		$this->Created = new DateTime();
 		Db::Query('
-			INSERT INTO Artworks (ArtistId, Name, CompletedYear, CompletedYearIsCirca, Created, MuseumPage,
+			INSERT INTO Artworks (ArtistId, Name, UrlName, CompletedYear, CompletedYearIsCirca, Created, MuseumPage,
 			                      PublicationYear, PublicationYearPage, CopyrightPage, ArtworkPage)
 			VALUES (?,
 			        ?,
@@ -213,8 +213,9 @@ class Artwork extends PropertiesBase{
 			        ?,
 			        ?,
 			        ?,
+			        ?,
 			        ?)
-		', [$this->Artist->ArtistId, $this->Name, $this->CompletedYear, $this->CompletedYearIsCirca,
+		', [$this->Artist->ArtistId, $this->Name, $this->UrlName, $this->CompletedYear, $this->CompletedYearIsCirca,
 				$this->Created, $this->MuseumPage, $this->PublicationYear, $this->PublicationYearPage,
 				$this->CopyrightPage, $this->ArtworkPage]
 		);

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -195,6 +195,21 @@ class Artwork extends PropertiesBase{
 		return $result[0];
 	}
 
+	public static function GetByUrlPath($artistUrlName, $artworkUrlName): Artwork{
+		$result = Db::Query('
+				SELECT Artworks.*
+				from Artworks
+				inner join Artists using (ArtistId)
+				where Artists.UrlName = ? and Artworks.UrlName = ?
+			', [$artistUrlName, $artworkUrlName], 'Artwork');
+
+		if(sizeof($result) == 0){
+			return null;
+		}
+
+		return $result[0];
+	}
+
 	/**
 	 * @throws \Exceptions\ValidationException
 	 */

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -160,25 +160,13 @@ class Library{
 	}
 
 	/**
-	 * @return Artwork
-	 */
-	public static function GetArtworkBySlug(string $slug){
-		try{
-			return apcu_fetch('artwork-' . $slug);
-		}
-		catch(Safe\Exceptions\ApcuException $ex){
-			return null;
-		}
-	}
-
-	/**
 	* @param string $query
 	* @param string $status
 	* @param string $sort
 	* @return array<Artwork>
 	*/
 	public static function FilterArtwork(string $query = null, string $status = null, string $sort = null): array{
-		$artworks = self::GetFromApcu('artworks');
+		$artworks = Artwork::GetBrowsable();
 		$matches = $artworks;
 
 		if($sort === null){
@@ -266,7 +254,6 @@ class Library{
 		}
 		catch(Safe\Exceptions\ApcuException $ex){
 			Library::RebuildCache();
-			Library::RebuildArtworkCache();
 			try{
 				$results = apcu_fetch($variable);
 			}
@@ -530,18 +517,6 @@ class Library{
 		}
 
 		return $retval;
-	}
-
-	public static function RebuildArtworkCache(): void{
-		$artworks = Artwork::GetBrowsable();
-
-		apcu_delete('artworks');
-		apcu_store('artworks', $artworks);
-
-		apcu_delete(new APCUIterator('/^artwork-/'));
-		foreach($artworks as $artwork){
-			apcu_store('artwork-' . $artwork->Slug, $artwork);
-		}
 	}
 
 	public static function RebuildCache(): void{

--- a/www/admin/artworks/post.php
+++ b/www/admin/artworks/post.php
@@ -31,7 +31,6 @@ try{
 	}
 
 	$artwork->Save();
-	Library::RebuildArtworkCache();
 
 	http_response_code(303);
 	header('Location: /admin/artworks');

--- a/www/artworks/get.php
+++ b/www/artworks/get.php
@@ -3,9 +3,8 @@ require_once('Core.php');
 
 $artistUrlName = HttpInput::Str(GET, 'artist');
 $artworkUrlName = HttpInput::Str(GET, 'artwork');
-$slug = $artistUrlName . '/' . $artworkUrlName;
 
-$artwork = Library::GetArtworkBySlug($slug);
+$artwork = Artwork::GetByUrlPath($artistUrlName, $artworkUrlName);
 
 if($artwork === null){
 	Template::Emit404();


### PR DESCRIPTION
Hi @jobcurtis, this PR reverts #249. See the discussion about why we will store UrlName in the `Artworks` table. We'll need a UrlName in the `Artists` table, too, so this PR adds it. If you don't want to drop your `Artists` table, you can alter it:

```sql
ALTER TABLE Artists ADD COLUMN UrlName varchar(255) NULL AFTER Name;
```

@acabal: This change turned out to be easier than I thought. I think part of the feedback in #249 was to keep things straightforward and not add premature optimizations. That said, I did add an index on `Artworks.UrlName` in order to avoid table scans on `Artworks`. The query execution plan confirms it works correctly:

Without index on `Artworks.UrlName`:
```
MariaDB [se]> EXPLAIN SELECT Artworks.* from Artworks inner join Artists using (ArtistId) where Artists.UrlName = 'henri-fantin-latour' and Artworks.UrlName = 'night';                                         
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-------------+
| id   | select_type | table    | type   | possible_keys | key     | key_len | ref                  | rows | Extra       |
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-------------+
|    1 | SIMPLE      | Artworks | ALL    | NULL          | NULL    | NULL    | NULL                 | 63   | Using where |
|    1 | SIMPLE      | Artists  | eq_ref | PRIMARY       | PRIMARY | 4       | se.Artworks.ArtistId | 1    | Using where |
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-------------+
```

With index on `Artworks.UrlName`:
```
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-----------------------+
| id   | select_type | table    | type   | possible_keys | key     | key_len | ref                  | rows | Extra                 |
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-----------------------+
|    1 | SIMPLE      | Artworks | ref    | index2        | index2  | 1023    | const                | 1    | Using index condition |
|    1 | SIMPLE      | Artists  | eq_ref | PRIMARY       | PRIMARY | 4       | se.Artworks.ArtistId | 1    | Using where           |
+------+-------------+----------+--------+---------------+---------+---------+----------------------+------+-----------------------+
```

As you wrote, with the low expected traffic and small scale of the artworks site, a table scan is probably no big deal, but the index seemed appropriate.