### PR TITLE
Move artwork creation logic from `artworks/post.php` to `Artwork.php`

### DIFF
--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -78,6 +78,9 @@ class Artist extends PropertiesBase{
 		$this->ArtistId = Db::GetLastInsertedId();
 	}
 
+	/**
+	 * @throws \Exceptions\ValidationException
+	 */
 	public function GetOrCreate(): void{
 		$this->Validate();
 		$result = Db::Query('

--- a/lib/ArtworkTag.php
+++ b/lib/ArtworkTag.php
@@ -52,24 +52,23 @@ class ArtworkTag extends PropertiesBase{
 		$this->TagId = Db::GetLastInsertedId();
 	}
 
-	public static function GetOrCreate(?string $name): ArtworkTag{
-		if($name === null){
-			throw new Exceptions\InvalidArtworkTagException();
-		}
+	/**
+	 * @throws \Exceptions\ValidationException
+	 */
+	public function GetOrCreate(): void{
+		$this->Validate();
 
 		$result = Db::Query('
 				SELECT *
 				from Tags
 				where Name = ?
-			', [$name], 'ArtworkTag');
+			', [$this->Name], 'ArtworkTag');
 
-		if(sizeof($result) == 0){
-			$artworkTag = new ArtworkTag();
-			$artworkTag->Name = $name;
-			$artworkTag->Create();
-			return $artworkTag;
+		if (isset($result[0])){
+			$this->TagId = $result[0]->TagId;
+			return;
 		}
 
-		return $result[0];
+		$this->Create();
 	}
 }

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -102,6 +102,7 @@ const GITHUB_WEBHOOK_LOG_FILE_PATH =	'/var/log/local/webhooks-github.log'; // Mu
 const POSTMARK_WEBHOOK_LOG_FILE_PATH =	'/var/log/local/webhooks-postmark.log'; // Must be writable by `www-data` Unix user.
 const ZOHO_WEBHOOK_LOG_FILE_PATH =	'/var/log/local/webhooks-zoho.log'; // Must be writable by `www-data` Unix user.
 const DONATIONS_LOG_FILE_PATH =		'/var/log/local/donations.log'; // Must be writable by `www-data` Unix user.
+const ARTWORK_UPLOADS_LOG_FILE_PATH =	'/var/log/local/artwork-uploads.log'; // Must be writable by `www-data` Unix user.
 
 define('PD_YEAR', intval(gmdate('Y')) - 96);
 define('PD_STRING', 'January 1, ' . (PD_YEAR + 1));

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -44,5 +44,5 @@ try{
 
 } finally{
 	http_response_code(303);
-	header('Location: ' . '/artworks/new');
+	header('Location: /artworks/new');
 }

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -1,65 +1,6 @@
-<? /** @noinspection PhpComposerExtensionStubsInspection, PhpIncludeInspection */
+<? /** @noinspection PhpIncludeInspection */
 
 require_once('Core.php');
-
-/**
- * @throws \Exceptions\InvalidImageUploadException
- */
-function handleImageUpload(string $uploadTmp, Artwork $artwork): void{
-	$uploadInfo = getimagesize($uploadTmp);
-
-	if ($uploadInfo === false){
-		throw new Exceptions\InvalidImageUploadException();
-	}
-
-	if ($uploadInfo[2] !== IMAGETYPE_JPEG){
-		throw new Exceptions\InvalidImageUploadException('Uploaded image must be a JPG file.');
-	}
-
-	$imagePath = WEB_ROOT . $artwork->ImageUrl;
-	$thumbPath = WEB_ROOT . $artwork->ThumbUrl;
-
-	if (!move_uploaded_file($uploadTmp, $imagePath)){
-		throw new Exceptions\InvalidImageUploadException();
-	}
-
-	$src_w = $uploadInfo[0];
-	$src_h = $uploadInfo[1];
-
-	if ($src_h > $src_w){
-		$dst_h = COVER_THUMBNAIL_SIZE;
-		$dst_w = intval($dst_h * ($src_w / $src_h));
-	} else{
-		$dst_w = COVER_THUMBNAIL_SIZE;
-		$dst_h = intval($dst_w * ($src_h / $src_w));
-	}
-
-	$srcImage = imagecreatefromjpeg($imagePath);
-	$thumbImage = imagecreatetruecolor($dst_w, $dst_h);
-
-	imagecopyresampled($thumbImage, $srcImage, 0, 0, 0, 0, $dst_w, $dst_h, $src_w, $src_h);
-	imagejpeg($thumbImage, $thumbPath);
-}
-
-/**
- * @return array<ArtworkTag>
- * @throws \Exceptions\InvalidArtworkTagException
- */
-function parseArtworkTags(): array{
-	$artworkTags = HttpInput::Str(POST, 'artwork-tags', false);
-
-	if (!$artworkTags){
-		return array();
-	}
-
-	$artworkTags = array_map('trim', explode(',', $artworkTags)) ?? array();
-	$artworkTags = array_values(array_filter($artworkTags)) ?? array();
-	$artworkTags = array_unique($artworkTags);
-
-	return array_map(function ($artworkTag){
-		return ArtworkTag::GetOrCreate($artworkTag);
-	}, $artworkTags);
-}
 
 if (HttpInput::RequestMethod() != HTTP_POST){
 	http_response_code(405);
@@ -69,25 +10,19 @@ if (HttpInput::RequestMethod() != HTTP_POST){
 session_start();
 
 try{
-	$artist = new Artist();
-	$artist->Name = HttpInput::Str(POST, 'artist-name', false);
-	$artist->DeathYear = HttpInput::Int(POST, 'artist-year-of-death');
-
-	$artwork = new Artwork();
-
-	$artwork->Artist = $artist;
-	$artwork->Name = HttpInput::Str(POST, 'artwork-name', false);
-	$artwork->CompletedYear = HttpInput::Str(POST, 'artwork-year', false);
-	$artwork->CompletedYearIsCirca = HttpInput::Bool(POST, 'artwork-year-is-circa', false);
-	$artwork->ArtworkTags = parseArtworkTags();
-	$artwork->Created = new DateTime();
-	$artwork->Status = 'unverified';
-
-	$artwork->MuseumPage = HttpInput::Str(POST, 'pd-proof-museum-link', false);
-	$artwork->PublicationYear = HttpInput::Int(POST, 'pd-proof-year-of-publication');
-	$artwork->PublicationYearPage = HttpInput::Str(POST, 'pd-proof-year-of-publication-page', false);
-	$artwork->CopyrightPage = HttpInput::Str(POST, 'pd-proof-copyright-page', false);
-	$artwork->ArtworkPage = HttpInput::Str(POST, 'pd-proof-artwork-page', false);
+	$artwork = Artwork::Build(
+		artistName: HttpInput::Str(POST, 'artist-name', false),
+		artistDeathYear: HttpInput::Int(POST, 'artist-year-of-death'),
+		artworkName: HttpInput::Str(POST, 'artwork-name', false),
+		completedYear: HttpInput::Str(POST, 'artwork-year', false),
+		completedYearIsCirca: HttpInput::Bool(POST, 'artwork-year-is-circa', false),
+		artworkTags: HttpInput::Str(POST, 'artwork-tags', false),
+		publicationYear: HttpInput::Int(POST, 'pd-proof-year-of-publication'),
+		publicationYearPage: HttpInput::Str(POST, 'pd-proof-year-of-publication-page', false),
+		copyrightPage: HttpInput::Str(POST, 'pd-proof-copyright-page', false),
+		artworkPage: HttpInput::Str(POST, 'pd-proof-artwork-page', false),
+		museumPage: HttpInput::Str(POST, 'pd-proof-museum-link', false),
+	);
 
 	$expectCaptcha = HttpInput::Str(SESSION, 'captcha', false);
 	$actualCaptcha = HttpInput::Str(POST, 'captcha', false);
@@ -96,14 +31,9 @@ try{
 		throw new Exceptions\InvalidCaptchaException();
 	}
 
-	$artist->GetOrCreate();
-	$artwork->Create();
-
-	handleImageUpload($_FILES['color-upload']['tmp_name'], $artwork);
+	$artwork->Create($_FILES['color-upload']['tmp_name']);
 
 	$_SESSION['success-message'] = '“' . $artwork->Name . '” submitted successfully!';
-	http_response_code(303);
-	header('Location: ' . '/artworks/new');
 
 } catch (\Exceptions\SeException $exception){
 	$_SESSION['exception'] = $exception;
@@ -112,19 +42,7 @@ try{
 		$_SESSION['artwork'] = $artwork;
 	}
 
-	if (isset($artwork->ArtworkId)){
-		// clean up the uploaded file(s)
-		unlink(WEB_ROOT . $artwork->ImageUrl);
-		unlink(WEB_ROOT . $artwork->ThumbUrl);
-
-		// remove database entry
-		$artwork->Delete();
-	}
-
-	if (isset($artist->ArtistId)){
-		$artist->DeleteIfUnused();
-	}
-
+} finally{
 	http_response_code(303);
-	header('Location: /artworks/new');
+	header('Location: ' . '/artworks/new');
 }


### PR DESCRIPTION
Per [discussion](https://github.com/standardebooks/web/issues/234#issuecomment-1618593966), this PR moves construction of `Artwork` objects to the class itself.

The only functional changes are that tags/artists are no longer created if form validation fails. Also, failing to move/create image/thumbnail files will result in orphaned database objects (and a log message).

@acabal I've included you on this PR as it relates to your feedback.