### PR TITLE
Password protect the artwork admin pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ vendor/
 *.log
 www/manual/*
 !www/manual/index.php
+config/apache/htpasswd-standardebooks.org
 config/php/fpm/standardebooks.org-secrets.ini
 www/bulk-downloads/*/

--- a/config/apache/htpasswd-standardebooks.test
+++ b/config/apache/htpasswd-standardebooks.test
@@ -1,0 +1,1 @@
+artworkmod:$apr1$5QfyeL03$afc041/RgabxEhpgUcQlG1

--- a/config/apache/standardebooks.org.conf
+++ b/config/apache/standardebooks.org.conf
@@ -106,6 +106,13 @@ Define webroot /standardebooks.org/web
 		CGIPassAuth	on
 	</Directory>
 
+	<Directory "${webroot}/www/admin/">
+		AuthType Basic
+		AuthName "Restricted Content"
+		AuthUserFile ${webroot}/config/apache/htpasswd-standardebooks.org
+		Require valid-user
+	</Directory>
+
 	AddType			application/x-mobi8-ebook .azw3
 
 	<LocationMatch "^/ebooks/.+?/downloads/.+$">

--- a/config/apache/standardebooks.test.conf
+++ b/config/apache/standardebooks.test.conf
@@ -88,6 +88,13 @@ Define webroot /standardebooks.org/web
 		CGIPassAuth	on
 	</Directory>
 
+	<Directory "${webroot}/www/admin/">
+		AuthType Basic
+		AuthName "Restricted Content"
+		AuthUserFile ${webroot}/config/apache/htpasswd-standardebooks.test
+		Require valid-user
+	</Directory>
+
 	AddType			application/x-mobi8-ebook .azw3
 
 	<LocationMatch "^/ebooks/.+?/downloads/.+$">


### PR DESCRIPTION
Alex, this is something you mentioned in your first #234 comment. Would you be willing to review it?

I was expecting you to create the `htpasswd` file with usernames and passwords for artwork moderators via:

```
htpasswd [-c] config/apache/htpasswd-standardebooks.org <username>
```

which will be separate from the usernames and passwords for the test site.

cc: @jobcurtis because it will affect access to the `/admin` pages