### PR TITLE
Disallow duplicate artwork

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -4,7 +4,7 @@ use function Safe\filesize;
 
 /**
  * @property string $UrlName
- * @property string $Slug
+ * @property string $Url
  * @property array<ArtworkTag> $ArtworkTags
  * @property string $ArtworkTagsImploded
  * @property Artist $Artist
@@ -23,7 +23,7 @@ class Artwork extends PropertiesBase{
 	public $Status;
 	public $EbookWwwFilesystemPath;
 	protected $_UrlName;
-	protected $_Slug;
+	protected $_Url;
 	protected $_ArtworkTags = null;
 	protected $_Artist = null;
 	protected $_ImageUrl = null;
@@ -55,12 +55,12 @@ class Artwork extends PropertiesBase{
 	/**
 	 * @return string
 	 */
-	protected function GetSlug(): string{
-		if($this->_Slug === null){
-			$this->_Slug = $this->Artist->UrlName . '/' . $this->UrlName;
+	protected function GetUrl(): string{
+		if($this->_Url === null){
+			$this->_Url = '/artworks/' . $this->Artist->UrlName . '/' . $this->UrlName;
 		}
 
-		return $this->_Slug;
+		return $this->_Url;
 	}
 
 	/**

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -268,7 +268,8 @@ class Artwork extends PropertiesBase{
 	/**
 	 * @throws \Exceptions\ValidationException
 	 */
-	public function Save(): void{
+	public function Save(string $status): void{
+		$this->Status = $status;
 		$this->Validate();
 
 		Db::Query('

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -184,6 +184,12 @@ class Artwork extends PropertiesBase{
 			$error->Add(new Exceptions\InvalidArtworkException('Must have proof of public domain status.'));
 		}
 
+		$existingArtwork = Artwork::GetByUrlPath($this->Artist->UrlName, $this->UrlName);
+		// Unverified and declined artwork can match an existing object. Approved and In Use artwork cannot.
+		if($existingArtwork !== null && !in_array($this->Status, ['unverified', 'declined'])){
+			$error->Add(new Exceptions\InvalidArtworkException('Artwork already exisits: ' . SITE_URL . $existingArtwork->Url));
+		}
+
 		if($error->HasExceptions){
 			throw $error;
 		}

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -6,13 +6,13 @@ $artworks = $artworks ?? [];
 <? foreach($artworks as $artwork){ ?>
 	<li class="<?= $artwork->Status ?>">
 		<div class="thumbnail-container">
-			<a href="/artworks/<?= $artwork->Slug ?>">
+			<a href="<?= $artwork->Url ?>">
 				<picture>
 					<img src="<?= $artwork->ThumbUrl ?>" property="schema:image"/>
 				</picture>
 			</a>
 		</div>
-		<p>Title: <a href="/artworks/<?= $artwork->Slug ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
+		<p>Title: <a href="<?= $artwork->Url ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
 		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>

--- a/www/admin/artworks/get.php
+++ b/www/admin/artworks/get.php
@@ -5,6 +5,7 @@ $artworkId = HttpInput::Int(GET, 'artworkid');
 
 try{
 	$artwork = Artwork::Get($artworkId);
+	$existingArtwork = Artwork::GetByUrlPath($artwork->Artist->UrlName, $artwork->UrlName);
 }
 catch(Exceptions\SeException){
 	Template::Emit404();
@@ -16,10 +17,14 @@ catch(Exceptions\SeException){
 		<?= Template::ArtworkDetail(['artwork' => $artwork]) ?>
 	</section>
 	<h2>Review</h2>
+	<? if($existingArtwork === null){ ?>
 	<p>Review the metadata and PD proof for this artwork submission. Approve to make it available for future producers.</p>
+	<? }else{ ?>
+	<p>Artwork cannot be approved because <a href="<?= $existingArtwork->Url ?>"><?= Formatter::ToPlainText($existingArtwork->Name) ?> by <?= Formatter::ToPlainText($existingArtwork->Artist->Name) ?></a> exists with status: <?= Template::ArtworkStatus(['artwork' => $existingArtwork]) ?>. Contact the site admin if it should be approved with updated metadata, e.g., an altered title.</p>
+	<? } ?>
 	<form method="post" action="/admin/artworks/<?= $artwork->ArtworkId ?>">
 		<input type="hidden" name="_method" value="PATCH" />
-		<button name="status" value="approved">Approve</button>
+		<button name="status" value="approved" <? if($existingArtwork !== null){ ?>disabled<? } ?>>Approve</button>
 		<button name="status" value="declined" class="decline-button">Decline</button>
 	</form>
 </main>

--- a/www/admin/artworks/post.php
+++ b/www/admin/artworks/post.php
@@ -18,19 +18,16 @@ catch(Exceptions\SeException){
 session_start();
 
 try{
-	$newStatus = HttpInput::Str(POST, 'status');
-	switch($newStatus){
+	$artwork->Save(status: HttpInput::Str(POST, 'status'));
+
+	switch($artwork->Status){
 		case 'approved':
-			$artwork->Status = 'approved';
 			$_SESSION['approved-message'] = '“' . $artwork->Name . '” approved.';
 			break;
 		case 'declined':
-			$artwork->Status = 'declined';
 			$_SESSION['declined-message'] = '“' . $artwork->Name . '” declined.';
 			break;
 	}
-
-	$artwork->Save();
 
 	http_response_code(303);
 	header('Location: /admin/artworks');

--- a/www/css/artwork.css
+++ b/www/css/artwork.css
@@ -99,6 +99,8 @@ main.artworks nav ol li.highlighted a:hover,
 	background-color: var(--button-highlight);
 }
 
+button:disabled,
+button:disabled:hover,
 .artworks nav > a:not([href]){
 	cursor: default;
 	color: #efefef;


### PR DESCRIPTION
Job, following up on a [previous issue](https://github.com/standardebooks/web/issues/234#issuecomment-1636898313) you noted, this PR disallows these two situations:

1. Users cannot submit artwork that would match a URL of an existing approved or in-use artwork. That is, they can't submit something that would be a duplicate of something browsable. For example, they can't submit "Tramps" by Jules-Alexis Muenier if there is already artwork at `/jules-alexis-muenier/tramps`.
2. Admins can't approve unverified artwork in the same situation. (As you pointed out, this can happen by submitting two artworks with the same artist+name to the unverified state.)

Now a URL of the form `/artist-name/artwork-name` can match only one artwork. (As always, that artwork must be approved or in use.)

There are two small, related refactors in this PR, too:

1. Updated this `Save()` function to accept a `status` parameter to match what you did with `Build()` and `Create()`
2. Replaced the `Slug` property with a more useful `Url` property