### PR TITLE
Add alternate spellings for Artists

### DIFF
--- a/config/sql/se/AlternateSpellings.sql
+++ b/config/sql/se/AlternateSpellings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `AlternateSpellings` (
+  `ArtistId` int(10) unsigned NOT NULL,
+  `AlternateSpelling` varchar(255) NOT NULL,
+  UNIQUE KEY `idxUnique` (`ArtistId`,`AlternateSpelling`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -3,12 +3,14 @@ use Safe\DateTime;
 
 /**
  * @property string $UrlName
+ * @property array<string> $AlternateSpellings
  */
 class Artist extends PropertiesBase{
 	public $ArtistId;
 	public $Name;
 	public $DeathYear;
 	protected $_UrlName;
+	protected $_AlternateSpellings;
 
 	// *******
 	// GETTERS
@@ -23,6 +25,27 @@ class Artist extends PropertiesBase{
 		}
 
 		return $this->_UrlName;
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	protected function GetAlternateSpellings(): array{
+		if($this->_AlternateSpellings === null){
+			$this->_AlternateSpellings = array();
+
+			$result = Db::Query('
+					SELECT *
+					from AlternateSpellings
+					where ArtistId = ?
+				', [$this->ArtistId], 'stdClass');
+
+			foreach($result as $row){
+				$this->_AlternateSpellings[] = $row->AlternateSpelling;
+			}
+		}
+
+		return $this->_AlternateSpellings;
 	}
 
 	// *******
@@ -106,6 +129,12 @@ class Artist extends PropertiesBase{
 		Db::Query('
 			DELETE
 			FROM Artists
+			WHERE ArtistId NOT IN (SELECT ArtistId FROM Artworks)
+			  AND ArtistId = ?
+		', [$this->ArtistId]);
+		Db::Query('
+			DELETE
+			FROM AlternateSpellings
 			WHERE ArtistId NOT IN (SELECT ArtistId FROM Artworks)
 			  AND ArtistId = ?
 		', [$this->ArtistId]);

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -308,6 +308,7 @@ class Artwork extends PropertiesBase{
 		$searchString = $this->Name;
 
 		$searchString .= ' ' . $this->Artist->Name;
+		$searchString .= ' ' . implode(' ', $this->Artist->AlternateSpellings);
 
 		foreach($this->ArtworkTags as $tag){
 			$searchString .= ' ' . $tag->Name;

--- a/templates/AdminArtworkList.php
+++ b/templates/AdminArtworkList.php
@@ -11,7 +11,10 @@ $artworks = $artworks ?? [];
 			</picture>
 		</div>
 		<p>Title: <a href="/admin/artworks/<?= $artwork->ArtworkId ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
-		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
+		<p>
+			Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span>
+			<? if(sizeof($artwork->Artist->AlternateSpellings) > 0){ ?>(<abbr>AKA</abbr> <span class="author" typeof="schema:Person" property="schema:name"><?= implode('</span>, <span class="author" typeof="schema:Person" property="schema:name">', array_map('Formatter::ToPlainText', $artwork->Artist->AlternateSpellings)) ?></span>)<? } ?>
+		</p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
 		</div>

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -12,7 +12,11 @@
 	</tr>
 	<tr>
 		<td>Artist</td>
-		<td><?= Formatter::ToPlainText($artwork->Artist->Name) ?><? if($artwork->Artist->DeathYear !== null){ ?>, <abbr title="deceased">d.</abbr> <?= $artwork->Artist->DeathYear ?><? } ?></td>
+		<td>
+			<?= Formatter::ToPlainText($artwork->Artist->Name) ?>
+			<? if(sizeof($artwork->Artist->AlternateSpellings) > 0){ ?>(<abbr>AKA</abbr> <span class="author" typeof="schema:Person" property="schema:name"><?= implode('</span>, <span class="author" typeof="schema:Person" property="schema:name">', array_map('Formatter::ToPlainText', $artwork->Artist->AlternateSpellings)) ?></span>)<? } ?>
+			<? if($artwork->Artist->DeathYear !== null){ ?>, <abbr title="deceased">d.</abbr> <?= $artwork->Artist->DeathYear ?><? } ?>
+		</td>
 	</tr>
 	<tr>
 		<td>Year completed</td>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -13,7 +13,10 @@ $artworks = $artworks ?? [];
 			</a>
 		</div>
 		<p>Title: <a href="/artworks/<?= $artwork->Slug ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
-		<p>Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span></p>
+		<p>
+			Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span>
+			<? if(sizeof($artwork->Artist->AlternateSpellings) > 0){ ?>(<abbr>AKA</abbr> <span class="author" typeof="schema:Person" property="schema:name"><?= implode('</span>, <span class="author" typeof="schema:Person" property="schema:name">', array_map('Formatter::ToPlainText', $artwork->Artist->AlternateSpellings)) ?></span>)<? } ?>
+		</p>
 		<div>
 			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
 			<p>Status: <?= Template::ArtworkStatus(['artwork' => $artwork]) ?></p>


### PR DESCRIPTION
Alex mentioned this in a [Nov 2021 discussion](https://groups.google.com/g/standardebooks/c/Y-0WRq1Gmvo/m/vWXY54cKBgAJ):

> Fuzzy search is necessary because often artists had their names romanized in different ways over the decades (Ilya Repin, Ílya Repín, Illia Riepin, Илья Репин?) 

With this PR the user can search via alternate spellings. For now, the alternate spellings must be inserted via SQL, e.g., 

```
MariaDB [se]> INSERT INTO AlternateSpellings VALUES (46, 'Ílya Repín'), (46, 'Illia Riepin'), (46, 'Илья Репин');
```

but once they are inserted the search on alternate spellings works as expected:

![Screenshot 2023-07-22 1 32 25 PM](https://github.com/standardebooks/web/assets/136965/3e87444e-6bd2-437f-ab0a-20e90ae65d9c)
