### PR TITLE
Add width and height dimensions to image size

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -132,6 +132,11 @@ class Artwork extends PropertiesBase{
 			$sizeNumber = sprintf('%.1f', $bytes / pow(1024, $factor));
 			$sizeUnit = $sizes[$factor] ?? '';
 			$this->_ImageSize = $sizeNumber . $sizeUnit;
+
+			list($imageWidth, $imageHeight) = getimagesize(WEB_ROOT . $this->ImageUrl);
+			if($imageWidth && $imageHeight){
+				$this->_ImageSize .= ' (' . $imageWidth . ' × ' . $imageHeight . ')';
+			}
 		}
 		catch(Exception $ex){
 			// Image doesn't exist


### PR DESCRIPTION
Following [SEMoS 8.8.7.1](https://standardebooks.org/manual/1.7.3/8-typography#8.8.7.1), I used the Unicode multiplication glyph.

See the "File size:	1.0M (2327 × 2980)" passage in the screenshot:

![Screenshot 2023-08-18 10 06 32 AM](https://github.com/standardebooks/web/assets/136965/ef3c573e-3906-4b74-841d-74df4e84be32)
