### PR TITLE
Remove "Title: " and "Author: " from ArtworkList

### DIFF
--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -18,9 +18,9 @@ $useAdminUrl = $useAdminUrl ?? false;
 				</picture>
 			</a>
 		</div>
-		<p>Title: <a href="<?= $url ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
+		<p><a href="<?= $url ?>" property="schema:name"><?= Formatter::ToPlainText($artwork->Name) ?></a></p>
 		<p>
-			Artist: <span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span>
+			<span class="author" typeof="schema:Person" property="schema:name"><?= Formatter::ToPlainText($artwork->Artist->Name) ?></span>
 			<? if(sizeof($artwork->Artist->AlternateSpellings) > 0){ ?>(<abbr>AKA</abbr> <span class="author" typeof="schema:Person" property="schema:name"><?= implode('</span>, <span class="author" typeof="schema:Person" property="schema:name">', array_map('Formatter::ToPlainText', $artwork->Artist->AlternateSpellings)) ?></span>)<? } ?>
 		</p>
 		<div>

--- a/www/css/artwork.css
+++ b/www/css/artwork.css
@@ -158,8 +158,9 @@ ol.artwork-list > li img{
 	border-radius: .25rem;
 }
 
-ol.artwork-list > li > p:nth-of-type(1) > span{
+ol.artwork-list > li > p:nth-of-type(1) > a{
 	font-weight: bold;
+	text-decoration: none;
 }
 
 ol.artwork-list > li .author{


### PR DESCRIPTION
They are still in the ArtworkDetail table, but this cleans up the list a bit. The meaning should be clear from the context, especially with the improved style that matches ebook treatment.

Here is a before and after:

![Screenshot 2023-08-19 4 09 04 PM](https://github.com/standardebooks/web/assets/136965/7a1df7cf-4e95-4db0-8ec1-79a5e7245cb5)

![Screenshot 2023-08-19 4 05 02 PM](https://github.com/standardebooks/web/assets/136965/80f15345-28d2-4a33-aa09-075d21e79d0d)
