### PR TITLE
Update text to reflect changes in Dr Jekyll versions on PG

### DIFF
--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -69,7 +69,7 @@
 					</li>
 				</ul>
 				<p>Picking either the HTML or the epub version is fine as a starting point, but make sure to pick the one that appears to be the most accurate.</p>
-				<p>For this guide, we’ll use <i>The Strange Case of Dr. Jekyll and Mr. Hyde</i>, by Robert Louis Stevenson. If you search for it on Gutenberg, you’ll find that there are two versions; the <a href="https://www.gutenberg.org/ebooks/42" rel="nofollow">most popular one</a> is a poor choice to produce, because the transcriber included the page numbers smack in the middle of the text! What a pain those’d be to remove. The <a href="https://www.gutenberg.org/ebooks/43">less popular one</a> is a better choice to produce, because it’s a cleaner transcription.</p>
+				<p>For this guide, we’ll use <i>The Strange Case of Dr. Jekyll and Mr. Hyde</i>, by Robert Louis Stevenson. If you search for it on Gutenberg, you’ll find that there are two versions; we will use <a href="https://www.gutenberg.org/ebooks/43" rel="nofollow">this</a> one rather than <a href="https://www.gutenberg.org/ebooks/42" rel="nofollow">this</a> one, as it is a cleaner transcription, e.g. has more modern usage of punctuation and compound words, etc.</p>
 			</li>
 			<li>
 				<h2 id="locate">Locate page scans of your book online</h2>


### PR DESCRIPTION
A lot has changed with PG's Dr Jekylls since the guide was originally written: the one that used to be the most downloaded is now outpaced 8-1 by the one the guide uses, and the biggest problem stated by the guide (page numbers) are no longer present. In order to not have to change the wording if the situation changed again, I just referred to the versions generically (rather than "most/least popular"), left the reason for the choice (cleaner transcription), but updated why we thought it was cleaner.

See what you think; there isn't a lot of difference between the two versions now other than what's stated here; the version we're using has less commas, and more modern compound words (preoccupied rather than pre-occupied, anyone vs any one, etc.).