### PR TITLE
Remove trailing slashes from nav page links

### DIFF
--- a/www/artworks/index.php
+++ b/www/artworks/index.php
@@ -82,13 +82,13 @@ $queryString = preg_replace('/^&amp;/ius', '', $queryString);
 	<? } ?>
 	<? if($totalArtworkCount > 0){ ?>
 		<nav>
-			<a<? if($page > 1){ ?> href="/artworks/?page=<?= $page - 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="prev"<? }else{ ?> aria-disabled="true"<? } ?>>Back</a>
+			<a<? if($page > 1){ ?> href="/artworks?page=<?= $page - 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="prev"<? }else{ ?> aria-disabled="true"<? } ?>>Back</a>
 			<ol>
 			<? for($i = 1; $i < $pages + 1; $i++){ ?>
-				<li<? if($page == $i){ ?> class="highlighted"<? } ?>><a href="/artworks/?page=<?= $i ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>"><?= $i ?></a></li>
+				<li<? if($page == $i){ ?> class="highlighted"<? } ?>><a href="/artworks?page=<?= $i ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>"><?= $i ?></a></li>
 			<? } ?>
 			</ol>
-			<a<? if($page < ceil($totalArtworkCount / $perPage)){ ?> href="/artworks/?page=<?= $page + 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="next"<? }else{ ?> aria-disabled="true"<? } ?>>Next</a>
+			<a<? if($page < ceil($totalArtworkCount / $perPage)){ ?> href="/artworks?page=<?= $page + 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="next"<? }else{ ?> aria-disabled="true"<? } ?>>Next</a>
 		</nav>
 	<? } ?>
 	</section>

--- a/www/ebooks/index.php
+++ b/www/ebooks/index.php
@@ -147,13 +147,13 @@ catch(Exceptions\InvalidCollectionException $ex){
 	<? } ?>
 	<? if(sizeof($ebooks) > 0 && $collection === null){ ?>
 		<nav>
-			<a<? if($page > 1){ ?> href="/ebooks/?page=<?= $page - 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="prev"<? }else{ ?> aria-disabled="true"<? } ?>>Back</a>
+			<a<? if($page > 1){ ?> href="/ebooks?page=<?= $page - 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="prev"<? }else{ ?> aria-disabled="true"<? } ?>>Back</a>
 			<ol>
 			<? for($i = 1; $i < $pages + 1; $i++){ ?>
-				<li<? if($page == $i){ ?> class="highlighted"<? } ?>><a href="/ebooks/?page=<?= $i ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>"><?= $i ?></a></li>
+				<li<? if($page == $i){ ?> class="highlighted"<? } ?>><a href="/ebooks?page=<?= $i ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>"><?= $i ?></a></li>
 			<? } ?>
 			</ol>
-			<a<? if($page < ceil($totalEbooks / $perPage)){ ?> href="/ebooks/?page=<?= $page + 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="next"<? }else{ ?> aria-disabled="true"<? } ?>>Next</a>
+			<a<? if($page < ceil($totalEbooks / $perPage)){ ?> href="/ebooks?page=<?= $page + 1 ?><? if($queryString != ''){ ?>&amp;<?= $queryString ?><? } ?>" rel="next"<? }else{ ?> aria-disabled="true"<? } ?>>Next</a>
 		</nav>
 	<? } ?>
 


### PR DESCRIPTION
Apache strips them out [via RewriteRule](https://github.com/standardebooks/web/blob/b919a7e829228b21a83c8a990d0b49116ba9652c/config/apache/standardebooks.org.conf#L189), so removing them here saves a 301 redirect.

Here is a "before" screenshot showing the 301 redirect on the first row of the Chrome network inspector:

![Screenshot 2023-09-03 4 16 10 PM](https://github.com/standardebooks/web/assets/136965/7cbfa13f-74a8-4c6c-bb92-f14b6260c8ee)

I copied the pagination approach for artworks from ebooks, so I'm applying the change in both places.