### PR TITLE
Script to update/insert existing cover art in the database

### DIFF
--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -120,6 +120,18 @@ class Artist extends PropertiesBase{
 		$this->Create();
 	}
 
+	public static function FindMatch(string $artistName): ?Artist{
+		$result = Db::Query('
+			SELECT a.*
+			FROM Artists a LEFT JOIN AlternateSpellings alt USING (ArtistId)
+			WHERE a.Name = ? OR alt.AlternateSpelling = ?
+			ORDER BY a.DeathYear DESC
+			LIMIT 1;
+		', [$artistName, $artistName], 'Artist');
+
+		return $result[0] ?? null;
+	}
+
 	public function Delete(): void{
 		Db::Query('
 			DELETE

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -7,7 +7,7 @@ DESCRIPTION
 	Deploy a Standard Ebook source repository to the web.
 
 USAGE
-	deploy-ebook-to-www [-v,--verbose] [-g,--group GROUP] [--webroot WEBROOT] [--weburl WEBURL] [--no-images] [--no-build] [--no-epubcheck] [--no-recompose] [--no-feeds] [-l,--last-push-hash HASH] DIRECTORY [DIRECTORY...]
+	deploy-ebook-to-www [-v,--verbose] [-g,--group GROUP] [--webroot WEBROOT] [--weburl WEBURL] [--no-images] [--no-build] [--no-epubcheck] [--no-recompose] [--no-feeds] [--no-bulk-downloads] [--upsert-to-cover-art-database] [-l,--last-push-hash HASH] DIRECTORY [DIRECTORY...]
 		DIRECTORY is a bare source repository.
 		GROUP is a groupname. Defaults to "se".
 		WEBROOT is the path to your webroot. Defaults to "/standardebooks.org/web/www".
@@ -39,6 +39,8 @@ USAGE
 
 		With --no-bulk-downloads, don't generate bulk download files.
 
+		With --upsert-to-cover-art-database, update/insert cover in the cover art database.
+
 EOF
 	exit
 }
@@ -57,6 +59,7 @@ epubcheck="true"
 recompose="true"
 feeds="true"
 bulkDownloads="true"
+coverArtDatabase="false"
 
 if [ $#  -eq 0 ]; then
 	usage
@@ -114,6 +117,10 @@ while [ $# -gt 0 ]; do
 			bulkDownloads="false"
 			shift 1
 			;;
+		--upsert-to-cover-art-database)
+			coverArtDatabase="true"
+			shift 1
+			;;
 		*) break ;;
 	esac
 done
@@ -146,6 +153,10 @@ fi
 
 if ! [ -f "${scriptsDir}"/generate-bulk-downloads ]; then
 	die "\"${scriptsDir}\"/generate-bulk-downloads\" is not a file or could not be found."
+fi
+
+if ! [ -f "${scriptsDir}"/upsert-to-cover-art-database ]; then
+	die "\"${scriptsDir}\"/upsert-to-cover-art-database\" is not a file or could not be found."
 fi
 
 mkdir -p "${webRoot}"/images/covers/
@@ -384,6 +395,18 @@ do
 	if [ "${images}" = "true" ]; then
 		# Move the cover images over
 		mv "${imgWorkDir}/${urlSafeIdentifier}"*.{jpg,avif} "${webRoot}/images/covers/"
+	fi
+
+	if [ "${coverArtDatabase}" = "true" ]; then
+		if [ "${verbose}" = "true" ]; then
+			printf "Updating/inserting cover in the cover art database ... "
+		fi
+
+		"${scriptsDir}"/upsert-to-cover-art-database --repoDir "${repoDir}" --workDir "${workDir}" --ebookWwwFilesystemPath "${webDir}"
+
+		if [ "${verbose}" = "true" ]; then
+			printf "Done.\n"
+		fi
 	fi
 
 	# Delete the now-empty work dir (empty except for .git)

--- a/scripts/upsert-to-cover-art-database
+++ b/scripts/upsert-to-cover-art-database
@@ -14,16 +14,19 @@ if(isset($options['v']) || isset($options['verbose'])){
 	$verbose = true;
 }
 
-function NullIfEmpty($elements): ?string{
+/**
+ * Coverts SimpleXMLElement objects with inner tags like this:
+ *   '<abbr>Mr.</abbr> Smith'
+ * to:
+ *   'Mr. Smith'
+ */
+function StripInnerTags($elements): ?string{
 	if($elements === false){
-		return false;
+		return null;
 	}
 
 	if(isset($elements[0])){
-		$str = (string)$elements[0];
-		if($str !== ''){
-			return $str;
-		}
+		return strip_tags($elements[0]->asXML());
 	}
 
 	return null;
@@ -44,7 +47,7 @@ chdir($repoDir);
 $contentOpf = shell_exec("git show HEAD:src/epub/content.opf");
 $xml = new SimpleXMLElement(str_replace('xmlns=', 'ns=', $contentOpf));
 $xml->registerXPathNamespace('dc', 'http://purl.org/dc/elements/1.1/');
-$artistName = NullIfEmpty($xml->xpath('/package/metadata/dc:contributor[@id="artist"]'));
+$artistName = StripInnerTags($xml->xpath('/package/metadata/dc:contributor[@id="artist"]'));
 if($artistName === null){
 	print("Error: Could not find artist name in content.opf\n");
 	exit('Error: missing artistName');
@@ -66,7 +69,7 @@ if(sizeof($matches) == 2){
 }
 
 $colophonXml = new SimpleXMLElement(str_replace('xmlns=', 'ns=', $rawColophon));
-$artworkName = NullIfEmpty($colophonXml->xpath('/html/body/main/section/p/i[@epub:type="se:name.visual-art.painting"]'));
+$artworkName = StripInnerTags($colophonXml->xpath('/html/body/main/section/p/i[@epub:type="se:name.visual-art.painting"]'));
 if($artworkName === null){
 	print("Error: Could not find artwork name in colophon.xhtml\n");
 	exit('Error: missing artworkName');

--- a/scripts/upsert-to-cover-art-database
+++ b/scripts/upsert-to-cover-art-database
@@ -1,0 +1,134 @@
+#!/usr/bin/php
+<?
+require_once('/standardebooks.org/web/lib/Core.php');
+
+$longopts = ['repoDir:', 'workDir:', 'ebookWwwFilesystemPath:', 'verbose'];
+$options = getopt('v', $longopts);
+
+$repoDir = $options['repoDir'] ?? false;
+$workDir = $options['workDir'] ?? false;
+$ebookWwwFilesystemPath = $options['ebookWwwFilesystemPath'] ?? false;
+
+$verbose = false;
+if(isset($options['v']) || isset($options['verbose'])){
+	$verbose = true;
+}
+
+function NullIfEmpty($elements): ?string{
+	if($elements === false){
+		return false;
+	}
+
+	if(isset($elements[0])){
+		$str = (string)$elements[0];
+		if($str !== ''){
+			return $str;
+		}
+	}
+
+	return null;
+}
+
+if(!$repoDir || !$workDir || !$ebookWwwFilesystemPath){
+	print("Expected usage: upsert-to-cover-art-database [-v] --repoDir <dir> --workDir <dir> --ebookWwwFilesystemPath <path>\n");
+	exit(1);
+}
+
+if($verbose){
+	print("\nrepoDir: $repoDir\n");
+	print("workDir: $workDir\n");
+	print("ebookWwwFilesystemPath: $ebookWwwFilesystemPath\n");
+}
+
+chdir($repoDir);
+$contentOpf = shell_exec("git show HEAD:src/epub/content.opf");
+$xml = new SimpleXMLElement(str_replace('xmlns=', 'ns=', $contentOpf));
+$xml->registerXPathNamespace('dc', 'http://purl.org/dc/elements/1.1/');
+$artistName = NullIfEmpty($xml->xpath('/package/metadata/dc:contributor[@id="artist"]'));
+if($artistName === null){
+	print("Error: Could not find artist name in content.opf\n");
+	exit('Error: missing artistName');
+}
+
+if(!file_exists($ebookWwwFilesystemPath . '/text/colophon.xhtml')){
+	exit('Error: no text/colophon.xhtml at ' . $ebookWwwFilesystemPath);
+}
+
+$rawColophon = file_get_contents($ebookWwwFilesystemPath . '/text/colophon.xhtml');
+if(empty($rawColophon)){
+	exit('Error: empty colophon at ' . $ebookWwwFilesystemPath);
+}
+
+preg_match('|a painting completed \w+ (\d+)|ius', $rawColophon, $matches);
+$completedYear = null;
+if(sizeof($matches) == 2){
+	$completedYear = (int)$matches[1];
+}
+
+$colophonXml = new SimpleXMLElement(str_replace('xmlns=', 'ns=', $rawColophon));
+$artworkName = NullIfEmpty($colophonXml->xpath('/html/body/main/section/p/i[@epub:type="se:name.visual-art.painting"]'));
+if($artworkName === null){
+	print("Error: Could not find artwork name in colophon.xhtml\n");
+	exit('Error: missing artworkName');
+}
+
+$artistUrlName = Formatter::MakeUrlSafe($artistName);
+$artworkUrlName = Formatter::MakeUrlSafe($artworkName);
+
+if($verbose){
+	print("artistName: $artistName\n");
+	print("artistUrlName: $artistUrlName\n");
+	print("completedYear: $completedYear\n");
+	print("artworkName: $artworkName\n");
+	print("artworkUrlName: $artworkUrlName\n");
+}
+
+$artwork = Artwork::GetByUrlPath($artistUrlName, $artworkUrlName);
+
+if($artwork === null){
+	if($verbose){
+		printf("No existing artwork found at %s/%s, inserting new artwork.\n", $artistUrlName, $artworkUrlName);
+	}
+
+	// The ebook colophon provides the artist's name, but not their death year.
+	// Prefer matching an existing artist to creating a new record with a null death year if possible.
+	$artist = Artist::FindMatch($artistName);
+	if($artist === null){
+		$artist = new Artist();
+		$artist->Name = $artistName;
+	}
+
+	$artwork = new Artwork();
+	$artwork->Artist = $artist;
+	$artwork->Name = $artworkName;
+	$artwork->CompletedYear = $completedYear;
+	$artwork->CompletedYearIsCirca = false;
+	$artwork->Created = new DateTime();
+	$artwork->Status = 'in_use';
+	$artwork->EbookWwwFilesystemPath = $ebookWwwFilesystemPath;
+
+	$coverSourceFile = tempnam($workDir, 'cover.source.jpg.');
+	// Doesn't handle repos with PNG instead of JPEG source files, i.e., images/cover.source.png
+	exec("git show HEAD:images/cover.source.jpg > $coverSourceFile", $shellOutput, $resultCode);
+	if($resultCode !== 0){
+		exit('Error: no images/cover.source.jpg in ' . $repoDir);
+	}
+
+	$artwork->CreateFromFilesystem($coverSourceFile);
+}else{
+	if($verbose){
+		printf("Existing artwork found at %s/%s, updating its status.\n", $artistUrlName, $artworkUrlName);
+	}
+
+	if($artwork->CompletedYear != $completedYear){
+		printf("Error: Existing database artwork completed year, %d, does not match ebook colophon completed year, %d. Not updating database.\n", $artwork->CompletedYear, $completedYear);
+		exit('Error: completed year');
+	}
+
+	if($artwork->Status === 'in_use'){
+		printf("Error: Existing database artwork already marked as 'in_use' by ebook '%s'. Not updating database.\n", $artwork->EbookWwwFilesystemPath);
+		exit('Error: in_use');
+	}
+
+	$artwork->MarkInUse($ebookWwwFilesystemPath);
+}


### PR DESCRIPTION
Hi @jobcurtis,

Here's a script I've been refining for a while, and I'm happy with it and eager for your feedback. I tested it by syncing and building all published ebooks locally and using the `deploy-ebook-to-www` script. The script can now update the database at the same time, but if you already have deployed all the ebooks, you can do a second loop over them like this:

```bash
cd /standardebooks.org/ebooks
for BOOK in $(find . -maxdepth 1 -type d); do
  /standardebooks.org/web/scripts/deploy-ebook-to-www -v --no-images --no-build  --no-epubcheck --no-recompose --no-feeds --no-bulk-downloads --upsert-to-cover-art-database $BOOK
done
```

It handles the common cases: 

1. Inserting a new image into the DB
2. Updating the status of an existing approved/unverified image to `in_use` by the correct ebook
3. No-op if the image is already in the DB and marked as `in_use`

One edge case it doesn't handle is that 29 repos out of the 878 that I ran it don't have a `images/cover.source.jpg`. They have a `images/cover.source.png` instead ([example](https://github.com/standardebooks/a-merritt_the-moon-pool/blob/master/images/cover.source.png)):

```
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/a-merritt_the-moon-pool.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/adam-smith_the-wealth-of-nations.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/agatha-christie_the-secret-adversary.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/alain-rene-lesage_gil-blas_tobias-smollett.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/black-hawk_the-autobiography-of-ma-ka-tai-me-she-kia-kiak-or-black-hawk.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/e-pauline-johnson_legends-of-vancouver.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/edith-wharton_ethan-frome.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/f-scott-fitzgerald_the-great-gatsby.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/h-rider-haggard_cleopatra.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/harold-frederic_the-damnation-of-theron-ware.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/henry-adams_democracy.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/henry-david-thoreau_a-week-on-the-concord-and-merrimack-rivers.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/hugh-walpole_the-dark-forest.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/j-s-fletcher_the-middle-temple-murder.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/j-w-von-goethe_the-sorrows-of-young-werther_r-d-boylan.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/john-w-campbell_invaders-from-the-infinite.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/john-w-campbell_islands-of-space.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/john-w-campbell_the-black-star-passes.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/lewis-carroll_through-the-looking-glass_john-tenniel.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/lord-dunsany_the-gods-of-pegana.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/oliver-goldsmith_the-vicar-of-wakefield.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/p-t-barnum_the-art-of-money-getting.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/peter-kropotkin_mutual-aid.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/thomas-carlyle_sartor-resartus.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/thornton-w-burgess_green-forest-stories.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/washington-irving_the-sketch-book-of-geoffrey-crayon-gent.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/william-makepeace-thackeray_vanity-fair.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/william-shakespeare_pericles.git
Error: no images/cover.source.jpg in /standardebooks.org/ebooks/william-shakespeare_richard-iii.git
```

The script doesn't look for the PNG, and our PHP code expects a JPEG anyway, so I think it's OK. I'm not sure that 100% coverage of the existing ebooks is high priority right now.