### PR TITLE
Updated wanted ebooks list: Norwegian Folktales

### DIFF
--- a/www/contribute/wanted-ebooks.php
+++ b/www/contribute/wanted-ebooks.php
@@ -315,6 +315,9 @@
 			<li>
 				<p><a href="https://www.gutenberg.org/ebooks/author/25394">Short stories by Manly Wade Wellman</a> to be compiled into a “Short Fiction” omnibus</p><!--patron-->
 			</li>
+			<li>
+				<p>Norwegian Folktales, by Peter Christen Asbjørnsen and Jørgen Moe, translated by George Dasent (<a href="https://gutenberg.org/ebooks/8933">part 1</a>, <a href="https://gutenberg.org/ebooks/36385">part 2</a>)</p>
+			</li>
 		</ul>
 		<h2>Advanced productions</h2>
 		<ul>


### PR DESCRIPTION
Asbjørnsen and Moe seem to be the Brothers Grimm of Norway, both in action and in reputation.

Gutenberg’s translations are by Dasent, and were described favorably by the Norwegian authors ([Wikipedia](https://en.wikipedia.org/wiki/Norwegian_Folktales#Translation_into_English)).