### PR TITLE
Set `upload_max_filesize` to 128M to allow larger image uploads.

### DIFF
--- a/config/php/fpm/standardebooks.org.ini
+++ b/config/php/fpm/standardebooks.org.ini
@@ -10,6 +10,9 @@ allow_url_fopen = false
 allow_url_include = false
 expose_php = Off
 
+post_max_size = 128M
+upload_max_filesize = 128M
+
 [Date]
 date.timezone = Etc/UTC
 

--- a/config/php/fpm/standardebooks.org.ini
+++ b/config/php/fpm/standardebooks.org.ini
@@ -10,8 +10,8 @@ allow_url_fopen = false
 allow_url_include = false
 expose_php = Off
 
-post_max_size = 128M
-upload_max_filesize = 128M
+post_max_size = 64M
+upload_max_filesize = 32M
 
 [Date]
 date.timezone = Etc/UTC

--- a/config/php/fpm/standardebooks.test.ini
+++ b/config/php/fpm/standardebooks.test.ini
@@ -7,6 +7,9 @@ allow_url_fopen = false
 allow_url_include = false
 expose_php = Off
 
+post_max_size = 128M
+upload_max_filesize = 128M
+
 [Date]
 date.timezone = Etc/UTC
 

--- a/config/php/fpm/standardebooks.test.ini
+++ b/config/php/fpm/standardebooks.test.ini
@@ -7,8 +7,8 @@ allow_url_fopen = false
 allow_url_include = false
 expose_php = Off
 
-post_max_size = 128M
-upload_max_filesize = 128M
+post_max_size = 64M
+upload_max_filesize = 32M
 
 [Date]
 date.timezone = Etc/UTC

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -209,10 +209,10 @@ class Artwork extends PropertiesBase{
 
 	/** @throws \Exceptions\InvalidImageUploadException */
 	private function ValidateImageUpload(string $uploadPath): void{
-		$uploadInfo = getimagesize($uploadPath);
-
-		if ($uploadInfo === false){
-			throw new Exceptions\InvalidImageUploadException();
+		try{
+			$uploadInfo = getimagesize($uploadPath);
+		} catch (\Safe\Exceptions\ImageException $exception){
+			throw new Exceptions\InvalidImageUploadException('Could not handle upload: ' . $exception->getMessage());
 		}
 
 		if ($uploadInfo[2] !== IMAGETYPE_JPEG){

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -31,6 +31,16 @@ try{
 		throw new Exceptions\InvalidCaptchaException();
 	}
 
+	if ($_FILES['color-upload']['error'] > 0){
+		// see https://www.php.net/manual/en/features.file-upload.errors.php
+		$message = match ($_FILES['color-upload']['error']){
+			1 => 'Image upload too large (maximum ' . ini_get('upload_max_filesize') . ')',
+			default => 'Image failed to upload',
+		};
+
+		throw new \Exceptions\InvalidImageUploadException($message);
+	}
+
 	$artwork->Create($_FILES['color-upload']['tmp_name']);
 
 	$_SESSION['success-message'] = '“' . $artwork->Name . '” submitted successfully!';

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -9,7 +9,28 @@ if (HttpInput::RequestMethod() != HTTP_POST){
 
 session_start();
 
+function post_max_size_bytes(): int{
+	$post_max_size = ini_get('post_max_size');
+	$unit = substr($post_max_size, -1);
+	$size = (int) substr($post_max_size, 0, -1);
+
+	return match ($unit) {
+		'g', 'G' => $size * 1024 * 1024 * 1024,
+		'm', 'M' => $size * 1024 * 1024,
+		'k', 'K' => $size * 1024,
+		default => $size
+	};
+}
+
 try{
+	if (empty($_POST) || empty($_FILES)){
+		if ($_SERVER['CONTENT_LENGTH'] > post_max_size_bytes()){
+			throw new \Exceptions\InvalidRequestException("Request too large (maximum " . ini_get('post_max_size') . ')');
+		} else{
+			throw new \Exceptions\InvalidRequestException();
+		}
+	}
+
 	$artwork = Artwork::Build(
 		artistName: HttpInput::Str(POST, 'artist-name', false),
 		artistDeathYear: HttpInput::Int(POST, 'artist-year-of-death'),
@@ -31,11 +52,12 @@ try{
 		throw new Exceptions\InvalidCaptchaException();
 	}
 
-	if ($_FILES['color-upload']['error'] > 0){
+	$uploadError = $_FILES['color-upload']['error'];
+	if ($uploadError > 0){
 		// see https://www.php.net/manual/en/features.file-upload.errors.php
-		$message = match ($_FILES['color-upload']['error']){
+		$message = match ($uploadError){
 			1 => 'Image upload too large (maximum ' . ini_get('upload_max_filesize') . ')',
-			default => 'Image failed to upload',
+			default => 'Image failed to upload (error code ' . $uploadError . ')',
 		};
 
 		throw new \Exceptions\InvalidImageUploadException($message);


### PR DESCRIPTION
The default is 2M, which is much too small for many images from museum websites.

Also added feedback when a user attempts to upload an image that is too large.