### PR TITLE
Add guidance for PD Proof section of new artwork form

### DIFF
--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -49,7 +49,7 @@ $showPDProofTip = $showPDProofTip ?? true;
 	<aside class="tip">
 		<p>PD proof must take the form of:</p>
 		<ul>
-			<li>Link to an approved museum page</li>
+			<li>Link to an <a href="/manual/latest/10-art-and-images#10.3.3.7.4">approved museum page</a></li>
 		</ul>
 		<p>or <strong>all</strong> of the following:</p>
 		<ol>

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -1,3 +1,8 @@
+<?
+$artwork = $artwork ?? null;
+$showPDProofTip = $showPDProofTip ?? true;
+?>
+
 <h1><?= Formatter::ToPlainText($artwork->Name) ?></h1>
 <a href="<?= $artwork->ImageUrl ?>">
 	<picture>
@@ -40,19 +45,21 @@
 	</tr>
 </table>
 <h2>PD Proof</h2>
-<aside class="tip">
-	<p>PD proof must take the form of:</p>
-	<ul>
-		<li>Link to an approved museum page</li>
-	</ul>
-	<p>or <strong>all</strong> of the following:</p>
-	<ol>
-		<li>Year book was published</li>
-		<li>Link to direct page scan of artwork (not just the start of the book, the direct page)</li>
-		<li>Link to direct page scan of page mentioning book publication year (not just the start of the book, the direct page)</li>
-		<li>Link to direct page scan of book copyright/rights statement page (may be the same as the publication year page but not always)</li>
-	</ol>
-</aside>
+<? if ($showPDProofTip){ ?>
+	<aside class="tip">
+		<p>PD proof must take the form of:</p>
+		<ul>
+			<li>Link to an approved museum page</li>
+		</ul>
+		<p>or <strong>all</strong> of the following:</p>
+		<ol>
+			<li>Year book was published</li>
+			<li>Link to direct page scan of artwork (not just the start of the book, the direct page)</li>
+			<li>Link to direct page scan of page mentioning book publication year (not just the start of the book, the direct page)</li>
+			<li>Link to direct page scan of book copyright/rights statement page (may be the same as the publication year page but not always)</li>
+		</ol>
+	</aside>
+<? } ?>
 <h3>Museum page</h3>
 <ul>
 	<li>Link to an approved museum page: <? if($artwork->MuseumPage !== null){ ?> <a href="<?= Formatter::ToPlainText($artwork->MuseumPage) ?>">Link</a><? }else{ ?>(not provided)<? } ?></li>

--- a/www/artworks/get.php
+++ b/www/artworks/get.php
@@ -13,7 +13,7 @@ if($artwork === null){
 ?><?= Template::Header(['title' => $artwork->Name, 'artwork' => true]) ?>
 <main class="artworks">
 	<section class="narrow">
-		<?= Template::ArtworkDetail(['artwork' => $artwork]) ?>
+		<?= Template::ArtworkDetail(['artwork' => $artwork, 'showPDProofTip' => false]) ?>
 	</section>
 </main>
 <?= Template::Footer() ?>

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -119,7 +119,7 @@ if ($exception){
 				<p>PD proof must take the form of:</p>
 				<fieldset>
 					<label>
-						Link to <a href="/manual/latest/10-art-and-images#10.3.3.7.4">approved museum page</a>
+						Link to an <a href="/manual/latest/10-art-and-images#10.3.3.7.4">approved museum page</a>
 						<input
 							type="url"
 							name="pd-proof-museum-link"
@@ -150,7 +150,7 @@ if ($exception){
 						</label>
 					</div>
 					<label>
-						Link to page with copyright details
+						Link to page with copyright details (might be same link as above)
 						<input
 							type="url"
 							name="pd-proof-copyright-page"
@@ -166,7 +166,7 @@ if ($exception){
 						/>
 					</label>
 				</fieldset>
-				<p>See the <a href="/manual/latest/10-art-and-images#10.3.3.7">Manual of Style</a> for full details on US-PD clearance.</p>
+				<p>See the <a href="/manual/latest/10-art-and-images#10.3.3.7">US-PD clearance section of the <abbr class="acronym">SEMoS</abbr></a> for details.</p>
 			</fieldset>
 			<fieldset>
 				<legend></legend>

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -116,6 +116,18 @@ if ($exception){
 			</fieldset>
 			<fieldset id="pd-proof">
 				<legend>Proof of Public Domain Status</legend>
+				<p>PD proof must take the form of:</p>
+				<fieldset>
+					<label>
+						Link to <a href="/manual/latest/10-art-and-images#10.3.3.7.4">approved museum page</a>
+						<input
+							type="url"
+							name="pd-proof-museum-link"
+							value="<?= Formatter::ToPlainText($artwork->MuseumPage) ?>"
+						/>
+					</label>
+				</fieldset>
+				<p>or direct links to page scans for <strong>all</strong> of the following:</p>
 				<fieldset>
 					<div>
 						<label>
@@ -154,14 +166,7 @@ if ($exception){
 						/>
 					</label>
 				</fieldset>
-				<label>
-					Link to museum page
-					<input
-						type="url"
-						name="pd-proof-museum-link"
-						value="<?= Formatter::ToPlainText($artwork->MuseumPage) ?>"
-					/>
-				</label>
+				<p>See the <a href="/manual/latest/10-art-and-images#10.3.3.7">Manual of Style</a> for full details on US-PD clearance.</p>
 			</fieldset>
 			<fieldset>
 				<legend></legend>

--- a/www/css/artwork.css
+++ b/www/css/artwork.css
@@ -219,8 +219,25 @@ main.artworks nav ol li a:hover{
 	max-width: calc(100% - 2rem);
 }
 
-form[action="/artworks"] fieldset:not(:first-child) {
+form[action="/artworks"] > fieldset:not(:first-child) {
 	margin-top: 1rem;
+}
+
+form[action="/artworks"] #pd-proof > fieldset {
+	border-left-color: var(--body-text);
+	border-left-width: 3px;
+	border-left-style: dotted;
+	padding-left: .75rem;
+}
+
+form[action="/artworks"] #pd-proof > p {
+	font-style: italic;
+	margin: .5rem 0;
+	border: none;
+}
+
+form[action="/artworks"] #pd-proof > p:first-of-type {
+	margin-top: 0;
 }
 
 form[action="/artworks"] legend {
@@ -239,19 +256,25 @@ form[action="/artworks"] div {
 
 form[action="/artworks"] div label {
 	flex-grow: 1;
-	min-width: 100%;
+	flex-basis: 100%;
 }
 
 form[action="/artworks"] div label:nth-of-type(1) {
 	flex-grow: 4;
 	flex-shrink: 0;
-	min-width: 60%;
+	flex-basis: 60%;
 }
 
 form[action="/artworks"] div label:nth-of-type(2) {
 	flex-grow: 1;
 	flex-shrink: 0;
-	min-width: 30%;
+	flex-basis: 30%;
+}
+
+@media(max-width: 730px) {
+	form[action="/artworks"] div label {
+		min-width: 100%;
+	}
 }
 
 main.artworks nav ol li:not(:first-child):not(:last-child):not(.highlighted){


### PR DESCRIPTION
I've added guidance around requirements for PD proof as discussed in #234. I didn't use the tip section because I'd like to keep the form fitting on one page where possible, and it felt like information was duplicated in the field labels. The border on the left is an attempt to make it clearer which fields the guidance is referring to.

I've also hidden the PD proof tip from the page when browsing submitted artwork, again as discussed.

![screenshot](https://github.com/standardebooks/web/assets/34031005/4e5762a2-9b0d-47c3-b8ee-59ed2d882a2f)
