### PR TITLE
Artwork::Validate: Check ArtworkId in URL check

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -205,9 +205,12 @@ class Artwork extends PropertiesBase{
 		}
 
 		$existingArtwork = Artwork::GetByUrlPath($this->Artist->UrlName, $this->UrlName);
-		// Unverified and declined artwork can match an existing object. Approved and In Use artwork cannot.
-		if($existingArtwork !== null && !in_array($this->Status, ['unverified', 'declined'])){
-			$error->Add(new Exceptions\InvalidArtworkException('Artwork already exisits: ' . SITE_URL . $existingArtwork->Url));
+		// Check for Artwork objects with the same URL but different Artwork IDs.
+		if($existingArtwork !== null && ($existingArtwork->ArtworkId !== $this->ArtworkId)){
+			// Unverified and declined artwork can match an existing object. Approved and In Use artwork cannot.
+			if(!in_array($this->Status, ['unverified', 'declined'])){
+				$error->Add(new Exceptions\InvalidArtworkException('Artwork already exisits: ' . SITE_URL . $existingArtwork->Url));
+			}
 		}
 
 		if($error->HasExceptions){


### PR DESCRIPTION
This is a minor change. I'm going to submit it without review. I discovered the problem when using the script to update artwork from Approved to In Use.

```
./scripts/upsert-to-cover-art-database -v --repoDir /standardebooks.org/ebooks/edith-wharton_the-house-of-mirth.git --workDir /tmp/edith --ebookWwwFilesystemPath /standardebooks.org/web/www/ebooks/edith-wharton/the-house-of-mirth
```

It turns out that _Mrs. Lloyd_ by Joshua Reynolds is already in use by [The House of Mirth](https://standardebooks.org/ebooks/edith-wharton/the-house-of-mirth) by is Edith Wharton. An earlier [bug](https://github.com/standardebooks/web/pull/270#issuecomment-1710415051) in how I handled inner tags like `<abbr>` in titles prevented me from noticing until now.
