### PR TITLE
Review form: Trim trailing whitespace on status

### DIFF
--- a/templates/ArtworkStatus.php
+++ b/templates/ArtworkStatus.php
@@ -3,14 +3,8 @@
 $artwork = $artwork ?? null;
 ?>
 <? if($artwork !== null){ ?>
-	<? if($artwork->Status === "approved"){ ?>
-		Approved
-	<? }else if($artwork->Status === "in_use"){ ?>
-		In use
-		<? if($artwork->Ebook !== null && $artwork->Ebook->Url !== null){ ?>
-			 by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a>
-		<? } ?>
-	<? }else{ ?>
-		<?= Formatter::ToPlainText($artwork->Status) ?>
-	<? } ?>
+<? if($artwork->Status === 'approved'){ ?>Approved<? } ?>
+<? if($artwork->Status === 'declined'){ ?>Declined<? } ?>
+<? if($artwork->Status === 'unverified'){ ?>Unverified<? } ?>
+<? if($artwork->Status === 'in_use'){ ?>In use<? if($artwork->Ebook !== null && $artwork->Ebook->Url !== null){ ?> by <a href="<?= $artwork->Ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::ToPlainText($artwork->Ebook->Title) ?></span></a><? } ?><? } ?>
 <? } ?>


### PR DESCRIPTION
This is a bit of a hack, but there are several places in `Template::ArtworkStatus` that can introduce trailing whitespace, and I'd rather leave that template formatted as-is, so I added a `trim()` call where it's needed when using the status in a sentence. (Using the status in the table above is fine.)