### PR TITLE
Fix artist name sort for names with diacritics

### DIFF
--- a/lib/Library.php
+++ b/lib/Library.php
@@ -203,9 +203,17 @@ class Library{
 
 		switch($sort){
 			case SORT_COVER_ARTIST_ALPHA:
-				usort($matches, function($a, $b){
-					return strcmp(mb_strtolower($a->Artist->Name), mb_strtolower($b->Artist->Name));
-				});
+				$collator = Collator::create('en_US'); // Used for sorting letters with diacritics like in artist names
+				if($collator === null){
+					usort($matches, function($a, $b){
+						return strcmp(mb_strtolower($a->Artist->Name), mb_strtolower($b->Artist->Name));
+					});
+				}else{
+					usort($matches, function($a, $b) use($collator){
+						return $collator->compare($a->Artist->Name, $b->Artist->Name);
+					});
+				}
+
 				break;
 
 			case SORT_COVER_ARTWORK_CREATED_NEWEST:

--- a/templates/ArtworkSearchForm.php
+++ b/templates/ArtworkSearchForm.php
@@ -14,7 +14,7 @@
 		<span>
 			<select name="sort">
 				<option value="<?= SORT_COVER_ARTWORK_CREATED_NEWEST ?>"<? if($sort == SORT_COVER_ARTWORK_CREATED_NEWEST){ ?> selected="selected"<? } ?>>Added date (new &#x2192; old)</option>
-				<option value="<?= SORT_COVER_ARTIST_ALPHA ?>"<? if ($sort == SORT_COVER_ARTIST_ALPHA){ ?> selected="selected"<? } ?>>Artist name  (a &#x2192; z)</option>
+				<option value="<?= SORT_COVER_ARTIST_ALPHA ?>"<? if ($sort == SORT_COVER_ARTIST_ALPHA){ ?> selected="selected"<? } ?>>Artist name (a &#x2192; z)</option>
 				<option value="<?= SORT_COVER_ARTWORK_COMPLETED_NEWEST ?>"<? if($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){ ?> selected="selected"<? } ?>>Completed date (new &#x2192; old)</option>
 			</select>
 		</span>


### PR DESCRIPTION
Without the fix, names like Édouard Manet and Élisabeth Louise Vigée Le Brun were sorted at the end of the list when choosing the sort order "Artist name (a → z)".

Here's a screenshot of it working with the fix:

![Screenshot 2023-10-07 12 20 39 AM](https://github.com/standardebooks/web/assets/136965/630fcfc8-089b-448c-af77-09ee05afd4ca)
