### PR TITLE
Fix errors found by PHPStan

### DIFF
--- a/config/phpstan/phpstan.neon
+++ b/config/phpstan/phpstan.neon
@@ -28,3 +28,6 @@ parameters:
 		- DONATION_ALERT_ON
 		- DONATION_DRIVE_ON
 		- DONATION_DRIVE_COUNTER_ON
+	earlyTerminatingMethodCalls:
+		Template:
+			- Emit404

--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -112,7 +112,7 @@ class Artist extends PropertiesBase{
 			WHERE Name = ? AND DeathYear = ?
 		', [$this->Name, $this->DeathYear], 'Artist');
 
-		if (isset($result[0])){
+		if(isset($result[0])){
 			$this->ArtistId = $result[0]->ArtistId;
 			return;
 		}

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -1,12 +1,16 @@
 <?
 use Safe\DateTime;
+use function Safe\apcu_fetch;
 use function Safe\copy;
 use function Safe\filesize;
 use function Safe\getimagesize;
+use function Safe\imagecopyresampled;
 use function Safe\imagecreatefromjpeg;
 use function Safe\imagecreatetruecolor;
 use function Safe\imagejpeg;
+use function Safe\preg_replace;
 use function Safe\rename;
+use function Safe\sprintf;
 use function Safe\tempnam;
 
 /**
@@ -129,7 +133,7 @@ class Artwork extends PropertiesBase{
 		try{
 			$bytes = @filesize(WEB_ROOT . $this->ImageUrl);
 			$sizes = 'BKMGTP';
-			$factor = floor((strlen($bytes) - 1) / 3);
+			$factor = intval(floor((strlen((string)$bytes) - 1) / 3));
 			$sizeNumber = sprintf('%.1f', $bytes / pow(1024, $factor));
 			$sizeUnit = $sizes[$factor] ?? '';
 			$this->_ImageSize = $sizeNumber . $sizeUnit;
@@ -253,7 +257,7 @@ class Artwork extends PropertiesBase{
 		return $result[0];
 	}
 
-	public static function GetByUrlPath($artistUrlName, $artworkUrlName): ?Artwork{
+	public static function GetByUrlPath(string $artistUrlName, string $artworkUrlName): ?Artwork{
 		$result = Db::Query('
 				SELECT Artworks.*
 				from Artworks
@@ -270,7 +274,7 @@ class Artwork extends PropertiesBase{
 	}
 
 	public static function Build(string $artistName, ?int $artistDeathYear, string $artworkName, ?int $completedYear,
-				     bool $completedYearIsCirca, ?string $artworkTags, ?int $publicationYear,
+				     ?bool $completedYearIsCirca, ?string $artworkTags, ?int $publicationYear,
 				     ?string $publicationYearPage, ?string $copyrightPage, ?string $artworkPage,
 				     ?string $museumPage): Artwork{
 		$artist = new Artist();
@@ -298,8 +302,8 @@ class Artwork extends PropertiesBase{
 	private static function ParseArtworkTags(?string $artworkTags): array{
 		if(!$artworkTags) return array();
 
-		$artworkTags = array_map('trim', explode(',', $artworkTags)) ?? array();
-		$artworkTags = array_values(array_filter($artworkTags)) ?? array();
+		$artworkTags = array_map('trim', explode(',', $artworkTags));
+		$artworkTags = array_values(array_filter($artworkTags));
 		$artworkTags = array_unique($artworkTags);
 
 		return array_map(function ($str){

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -395,7 +395,8 @@ class Artwork extends PropertiesBase{
 		if($src_h > $src_w){
 			$dst_h = COVER_THUMBNAIL_SIZE;
 			$dst_w = intval($dst_h * ($src_w / $src_h));
-		}else{
+		}
+		else{
 			$dst_w = COVER_THUMBNAIL_SIZE;
 			$dst_h = intval($dst_w * ($src_h / $src_w));
 		}

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -96,8 +96,8 @@ class Artwork extends PropertiesBase{
 	 * @throws \Exceptions\InvalidArtworkException
 	 */
 	protected function GetImageUrl(): string{
-		if ($this->_ImageUrl == null){
-			if ($this->ArtworkId == null){
+		if($this->_ImageUrl == null){
+			if($this->ArtworkId == null){
 				throw new \Exceptions\InvalidArtworkException();
 			}
 
@@ -111,8 +111,8 @@ class Artwork extends PropertiesBase{
 	 * @throws \Exceptions\InvalidArtworkException
 	 */
 	protected function GetThumbUrl(): string{
-		if ($this->_ThumbUrl == null){
-			if ($this->ArtworkId == null){
+		if($this->_ThumbUrl == null){
+			if($this->ArtworkId == null){
 				throw new \Exceptions\InvalidArtworkException();
 			}
 
@@ -148,7 +148,7 @@ class Artwork extends PropertiesBase{
 	}
 
 	protected function GetEbook(): ?Ebook{
-		if ($this->EbookWwwFilesystemPath !== null){
+		if($this->EbookWwwFilesystemPath !== null){
 			try{
 				$key = 'ebook-' . $this->EbookWwwFilesystemPath;
 				$this->_Ebook = apcu_exists($key) ? apcu_fetch($key) : null;
@@ -226,7 +226,7 @@ class Artwork extends PropertiesBase{
 			throw new Exceptions\InvalidImageUploadException('Could not handle upload: ' . $exception->getMessage());
 		}
 
-		if ($uploadInfo[2] !== IMAGETYPE_JPEG){
+		if($uploadInfo[2] !== IMAGETYPE_JPEG){
 			throw new Exceptions\InvalidImageUploadException('Uploaded image must be a JPG file.');
 		}
 	}
@@ -296,7 +296,7 @@ class Artwork extends PropertiesBase{
 
 	/** @return array<ArtworkTag> */
 	private static function ParseArtworkTags(?string $artworkTags): array{
-		if (!$artworkTags) return array();
+		if(!$artworkTags) return array();
 
 		$artworkTags = array_map('trim', explode(',', $artworkTags)) ?? array();
 		$artworkTags = array_values(array_filter($artworkTags)) ?? array();
@@ -388,10 +388,10 @@ class Artwork extends PropertiesBase{
 		$src_w = $uploadInfo[0];
 		$src_h = $uploadInfo[1];
 
-		if ($src_h > $src_w){
+		if($src_h > $src_w){
 			$dst_h = COVER_THUMBNAIL_SIZE;
 			$dst_w = intval($dst_h * ($src_w / $src_h));
-		} else{
+		}else{
 			$dst_w = COVER_THUMBNAIL_SIZE;
 			$dst_h = intval($dst_w * ($src_h / $src_w));
 		}

--- a/lib/ArtworkTag.php
+++ b/lib/ArtworkTag.php
@@ -64,7 +64,7 @@ class ArtworkTag extends PropertiesBase{
 				where Name = ?
 			', [$this->Name], 'ArtworkTag');
 
-		if (isset($result[0])){
+		if(isset($result[0])){
 			$this->TagId = $result[0]->TagId;
 			return;
 		}

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -180,7 +180,8 @@ class Library{
 					$matches[] = $artwork;
 				}
 			}
-		}else{
+		}
+		else{
 			$matches = [];
 			foreach($artworks as $artwork){
 				if(in_array($artwork->Status, [COVER_ARTWORK_STATUS_APPROVED, COVER_ARTWORK_STATUS_IN_USE], true)){
@@ -208,7 +209,8 @@ class Library{
 					usort($matches, function($a, $b){
 						return strcmp(mb_strtolower($a->Artist->Name), mb_strtolower($b->Artist->Name));
 					});
-				}else{
+				}
+				else{
 					usort($matches, function($a, $b) use($collator){
 						return $collator->compare($a->Artist->Name, $b->Artist->Name);
 					});

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -620,7 +620,7 @@ class Library{
 			// Sort the array by the ebook's ordinal in the collection. We use this custom sort function
 			// because an ebook may share the same place in a collection with another ebook; see above.
 			usort($sortItems, function($a, $b) {
-				if ($a->Ordinal == $b->Ordinal) {
+				if($a->Ordinal == $b->Ordinal) {
 				        return 0;
 				    }
 				    return ($a->Ordinal < $b->Ordinal) ? -1 : 1;

--- a/scripts/upsert-to-cover-art-database
+++ b/scripts/upsert-to-cover-art-database
@@ -118,7 +118,8 @@ if($artwork === null){
 	}
 
 	$artwork->CreateFromFilesystem($coverSourceFile);
-}else{
+}
+else{
 	if($verbose){
 		printf("Existing artwork found at %s/%s, updating its status.\n", $artistUrlName, $artworkUrlName);
 	}

--- a/templates/ArtworkDetail.php
+++ b/templates/ArtworkDetail.php
@@ -25,7 +25,7 @@ $showPDProofTip = $showPDProofTip ?? true;
 	</tr>
 	<tr>
 		<td>Year completed</td>
-		<td><? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></td>
+		<td><? if($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></td>
 	</tr>
 	<tr>
 		<td>File size</td>
@@ -45,7 +45,7 @@ $showPDProofTip = $showPDProofTip ?? true;
 	</tr>
 </table>
 <h2>PD Proof</h2>
-<? if ($showPDProofTip){ ?>
+<? if($showPDProofTip){ ?>
 	<aside class="tip">
 		<p>PD proof must take the form of:</p>
 		<ul>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -24,7 +24,7 @@ $useAdminUrl = $useAdminUrl ?? false;
 			<? if(sizeof($artwork->Artist->AlternateSpellings) > 0){ ?>(<abbr>AKA</abbr> <span class="author" typeof="schema:Person" property="schema:name"><?= implode('</span>, <span class="author" typeof="schema:Person" property="schema:name">', array_map('Formatter::ToPlainText', $artwork->Artist->AlternateSpellings)) ?></span>)<? } ?>
 		</p>
 		<div>
-			<p>Year completed: <? if ($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
+			<p>Year completed: <? if($artwork->CompletedYear === null){ ?>(unknown)<? }else{ ?><?= $artwork->CompletedYear ?><? if($artwork->CompletedYearIsCirca){ ?> (circa)<? } ?><? } ?></p>
 			<p>Status: <?= Template::ArtworkStatus(['artwork' => $artwork]) ?></p>
 			<? if(count($artwork->ArtworkTags) > 0){ ?>
 			<p>Tags: <ul class="tags"><? foreach($artwork->ArtworkTags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::ToPlainText($tag->Name) ?></a></li><? } ?></ul></p>

--- a/templates/ArtworkSearchForm.php
+++ b/templates/ArtworkSearchForm.php
@@ -14,7 +14,7 @@
 		<span>
 			<select name="sort">
 				<option value="<?= SORT_COVER_ARTWORK_CREATED_NEWEST ?>"<? if($sort == SORT_COVER_ARTWORK_CREATED_NEWEST){ ?> selected="selected"<? } ?>>Added date (new &#x2192; old)</option>
-				<option value="<?= SORT_COVER_ARTIST_ALPHA ?>"<? if ($sort == SORT_COVER_ARTIST_ALPHA){ ?> selected="selected"<? } ?>>Artist name (a &#x2192; z)</option>
+				<option value="<?= SORT_COVER_ARTIST_ALPHA ?>"<? if($sort == SORT_COVER_ARTIST_ALPHA){ ?> selected="selected"<? } ?>>Artist name (a &#x2192; z)</option>
 				<option value="<?= SORT_COVER_ARTWORK_COMPLETED_NEWEST ?>"<? if($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){ ?> selected="selected"<? } ?>>Completed date (new &#x2192; old)</option>
 			</select>
 		</span>

--- a/templates/Header.php
+++ b/templates/Header.php
@@ -39,7 +39,7 @@ if(!$isXslt){
 	<? if(Template::IsEreaderBrowser()){ ?>
 	<link rel="preload" as="font" href="/fonts/league-spartan-bold.ttf" type="font/ttf" crossorigin="anonymous"/>
 	<link href="/css/ereader.css?version=<?= filemtime(WEB_ROOT . '/css/ereader.css') ?>" media="screen" rel="stylesheet" type="text/css"/>
-	<? } else { ?>
+	<? }else{ ?>
 	<link href="/css/core.css?version=<?= filemtime(WEB_ROOT . '/css/core.css') ?>" media="screen" rel="stylesheet" type="text/css"/>
 	<? if($colorScheme == 'auto' || $colorScheme == 'dark'){ ?>
 	<link href="/css/dark.css?version=<?= filemtime(WEB_ROOT . '/css/dark.css') ?>" media="screen<? if($colorScheme == 'auto'){ ?> and (prefers-color-scheme: dark)<? } ?>" rel="stylesheet" type="text/css"/>

--- a/www/admin/artworks/index.php
+++ b/www/admin/artworks/index.php
@@ -1,6 +1,8 @@
 <?
 require_once('Core.php');
 
+use function Safe\session_unset;
+
 session_start();
 
 $approvedMessage = $_SESSION['approved-message'] ?? null;

--- a/www/admin/artworks/index.php
+++ b/www/admin/artworks/index.php
@@ -6,7 +6,7 @@ session_start();
 $approvedMessage = $_SESSION['approved-message'] ?? null;
 $declinedMessage = $_SESSION['declined-message'] ?? null;
 
-if ($approvedMessage || $declinedMessage){
+if($approvedMessage || $declinedMessage){
 	http_response_code(201);
 	session_unset();
 }
@@ -36,12 +36,12 @@ $unverifiedArtworks = array_slice($unverifiedArtworks, ($page - 1) * $perPage, $
 		</hgroup>
 
 		<section id="unapproved-artwork">
-			<? if ($approvedMessage){ ?>
+			<? if($approvedMessage){ ?>
 			<p class="message success">
 				<?= Formatter::ToPlainText($approvedMessage) ?>
 			</p>
 			<? } ?>
-			<? if ($declinedMessage){ ?>
+			<? if($declinedMessage){ ?>
 			<p class="message">
 				<?= Formatter::ToPlainText($declinedMessage) ?>
 			</p>

--- a/www/admin/artworks/post.php
+++ b/www/admin/artworks/post.php
@@ -18,7 +18,12 @@ catch(Exceptions\SeException){
 session_start();
 
 try{
-	$artwork->Save(status: HttpInput::Str(POST, 'status'));
+	$status = HttpInput::Str(POST, 'status', false);
+	if($status === null){
+		throw new \Exceptions\InvalidRequestException('Empty or invalid status');
+	}
+
+	$artwork->Save($status);
 
 	switch($artwork->Status){
 		case 'approved':

--- a/www/artworks/get.php
+++ b/www/artworks/get.php
@@ -1,8 +1,8 @@
 <?
 require_once('Core.php');
 
-$artistUrlName = HttpInput::Str(GET, 'artist');
-$artworkUrlName = HttpInput::Str(GET, 'artwork');
+$artistUrlName = HttpInput::Str(GET, 'artist') ?? '';
+$artworkUrlName = HttpInput::Str(GET, 'artwork') ?? '';
 
 $artwork = Artwork::GetByUrlPath($artistUrlName, $artworkUrlName);
 

--- a/www/artworks/index.php
+++ b/www/artworks/index.php
@@ -52,7 +52,7 @@ if($query != ''){
 	$queryString .= '&amp;query=' . urlencode($query);
 }
 
-if($status != ''){
+if($status !== null){
 	$queryString .= '&amp;status=' . urlencode($status);
 }
 

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -1,6 +1,9 @@
 <?php /** @noinspection PhpUndefinedMethodInspection,PhpIncludeInspection */
 require_once('Core.php');
 
+use function Safe\gmdate;
+use function Safe\session_unset;
+
 session_start();
 
 $successMessage = $_SESSION['success-message'] ?? null;

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -5,7 +5,7 @@ session_start();
 
 $successMessage = $_SESSION['success-message'] ?? null;
 
-if ($successMessage){
+if($successMessage){
 	http_response_code(201);
 	session_unset();
 }
@@ -16,7 +16,7 @@ $artist = $artwork->Artist ?? new Artist();
 
 $exception = $_SESSION['exception'] ?? null;
 
-if ($exception){
+if($exception){
 	http_response_code(422);
 	session_unset();
 }
@@ -39,7 +39,7 @@ if ($exception){
 
 		<?= Template::Error(['exception' => $exception]) ?>
 
-		<? if ($successMessage){ ?>
+		<? if($successMessage){ ?>
 			<p class="message success">
 				<?= Formatter::ToPlainText($successMessage) ?>
 			</p>

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -2,6 +2,9 @@
 
 require_once('Core.php');
 
+use function Safe\ini_get;
+use function Safe\substr;
+
 function post_max_size_bytes(): int{
 	$post_max_size = ini_get('post_max_size');
 	$unit = substr($post_max_size, -1);
@@ -31,11 +34,21 @@ try{
 		}
 	}
 
+	$artistName = HttpInput::Str(POST, 'artist-name', false);
+	if($artistName === null){
+		throw new \Exceptions\InvalidRequestException('Empty or invalid Artist Name');
+	}
+
+	$artworkName = HttpInput::Str(POST, 'artwork-name', false);
+	if($artworkName === null){
+		throw new \Exceptions\InvalidRequestException('Empty or invalid Artwork Name');
+	}
+
 	$artwork = Artwork::Build(
-		artistName: HttpInput::Str(POST, 'artist-name', false),
+		artistName: $artistName,
 		artistDeathYear: HttpInput::Int(POST, 'artist-year-of-death'),
-		artworkName: HttpInput::Str(POST, 'artwork-name', false),
-		completedYear: HttpInput::Str(POST, 'artwork-year', false),
+		artworkName: $artworkName,
+		completedYear: HttpInput::Int(POST, 'artwork-year'),
 		completedYearIsCirca: HttpInput::Bool(POST, 'artwork-year-is-circa', false),
 		artworkTags: HttpInput::Str(POST, 'artwork-tags', false),
 		publicationYear: HttpInput::Int(POST, 'pd-proof-year-of-publication'),
@@ -48,7 +61,7 @@ try{
 	$expectCaptcha = HttpInput::Str(SESSION, 'captcha', false);
 	$actualCaptcha = HttpInput::Str(POST, 'captcha', false);
 
-	if($expectCaptcha === '' || mb_strtolower($expectCaptcha) !== mb_strtolower($actualCaptcha)){
+	if($expectCaptcha === null || $actualCaptcha === null || mb_strtolower($expectCaptcha) !== mb_strtolower($actualCaptcha)){
 		throw new Exceptions\InvalidCaptchaException();
 	}
 


### PR DESCRIPTION
Alex made a similar fix in bd4b8d8944ef45069f6b983288a372ca79423ff4 on Jun 21, and I reused his approach from `lib/Ebook.php` for this line in `lib/Artwork.php`:

```php
$factor = intval(floor((strlen((string)$bytes) - 1) / 3));
```

One other benefit of running PHPStan: I found an actual, user-facing bug. Before these fixes, I was able to submit artwork with just spaces as the artist or artwork name. The submission would fail silently, and the error log contained:

```
Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: Artwork::Build(): Argument #1 ($artistName) must be of type string, null given, called in /standardebooks.org/web/www/artworks/post.php on line 48 and defined in /standardebooks.org/web/lib/Artwork.php:274\nStack trace:\n#0 /standardebooks.org/web/www/artworks/post.php(48): Artwork::Build()\n#1 {main}\n  thrown in /standardebooks.org/web/lib/Artwork.php on line 274'
```

Now we check for valid artist and artwork name before calling `Artwork::Build()` and return an error to the user if there's a problem.

I also included a separate commit for some code style fixes that accumulated over the last few months. e.g., `if (` -> `if(`. I'm responsible for lots of them, so no judgment. 