### PR TITLE
Artwork review: Explain existing/approved artwork

### DIFF
--- a/www/admin/artworks/get.php
+++ b/www/admin/artworks/get.php
@@ -19,8 +19,10 @@ catch(Exceptions\SeException){
 	<h2>Review</h2>
 	<? if($existingArtwork === null){ ?>
 	<p>Review the metadata and PD proof for this artwork submission. Approve to make it available for future producers.</p>
+	<? }elseif($existingArtwork->ArtworkId == $artwork->ArtworkId){ ?>
+	<p><? if($existingArtwork->Status == COVER_ARTWORK_STATUS_APPROVED){ ?><a href="<?= $existingArtwork->Url ?>">This artwork</a> is already approved. <? }elseif($existingArtwork->Status == COVER_ARTWORK_STATUS_IN_USE){ ?><a href="<?= $existingArtwork->Url ?>">This artwork</a> is already in use. <? } ?>Contact the site admin if it should be updated.</p>
 	<? }else{ ?>
-	<p>Artwork cannot be approved because <a href="<?= $existingArtwork->Url ?>"><?= Formatter::ToPlainText($existingArtwork->Name) ?> by <?= Formatter::ToPlainText($existingArtwork->Artist->Name) ?></a> exists with status: <?= Template::ArtworkStatus(['artwork' => $existingArtwork]) ?>. Contact the site admin if it should be approved with updated metadata, e.g., an altered title.</p>
+	<p>Artwork cannot be approved because a different artwork with the same title and artist already exists: <a href="<?= $existingArtwork->Url ?>"><?= Formatter::ToPlainText($existingArtwork->Name) ?> by <?= Formatter::ToPlainText($existingArtwork->Artist->Name) ?></a>. Contact the site admin if it should be approved with updated metadata, e.g., an altered title.</p>
 	<? } ?>
 	<form method="post" action="/admin/artworks/<?= $artwork->ArtworkId ?>">
 		<input type="hidden" name="_method" value="PATCH" />


### PR DESCRIPTION
There are two similar but different cases to explain to reviewers:

1. The reviewer is looking at the admin page of artwork that has already been approved or is in use. They can't approve it again.

2. The reviewer is looking at unverified artwork that has the same title and artist as a different approved or in use artwork. They can't approve it because it would create a duplicate.

Here are two screenshot examples of the cases:

1. 
![Screenshot 2023-10-08 10 18 26 PM](https://github.com/standardebooks/web/assets/136965/3f95cd65-062b-4b97-a2f2-72bef6469279)

2.
![Screenshot 2023-10-08 10 23 18 PM](https://github.com/standardebooks/web/assets/136965/a3801b3c-f2eb-45af-ba66-6f3abdacb238)

I'm open to rewording these.