### PR TITLE
Admin approved message: Add link to artwork

### DIFF
--- a/www/admin/artworks/index.php
+++ b/www/admin/artworks/index.php
@@ -5,12 +5,20 @@ use function Safe\session_unset;
 
 session_start();
 
-$approvedMessage = $_SESSION['approved-message'] ?? null;
-$declinedMessage = $_SESSION['declined-message'] ?? null;
+$approvedArtworkId = $_SESSION['approved-artwork-id'] ?? null;
+$declinedArtworkId = $_SESSION['declined-artwork-id'] ?? null;
 
-if($approvedMessage || $declinedMessage){
+if($approvedArtworkId || $declinedArtworkId){
 	http_response_code(201);
 	session_unset();
+}
+
+if($approvedArtworkId){
+	$approvedArtwork = Artwork::Get($approvedArtworkId);
+}
+
+if($declinedArtworkId){
+	$declinedArtwork = Artwork::Get($declinedArtworkId);
 }
 
 $page = HttpInput::Int(GET, 'page') ?? 1;
@@ -38,14 +46,14 @@ $unverifiedArtworks = array_slice($unverifiedArtworks, ($page - 1) * $perPage, $
 		</hgroup>
 
 		<section id="unapproved-artwork">
-			<? if($approvedMessage){ ?>
+			<? if($approvedArtwork){ ?>
 			<p class="message success">
-				<?= Formatter::ToPlainText($approvedMessage) ?>
+				<a href="<?= $approvedArtwork->Url ?>" property="schema:name"><?= Formatter::ToPlainText($approvedArtwork->Name) ?></a> approved.
 			</p>
 			<? } ?>
-			<? if($declinedMessage){ ?>
+			<? if($declinedArtwork){ ?>
 			<p class="message">
-				<?= Formatter::ToPlainText($declinedMessage) ?>
+				“<?= Formatter::ToPlainText($declinedArtwork->Name) ?>” declined.
 			</p>
 			<? } ?>
 			<? if($count == 0){ ?>

--- a/www/admin/artworks/post.php
+++ b/www/admin/artworks/post.php
@@ -27,10 +27,10 @@ try{
 
 	switch($artwork->Status){
 		case 'approved':
-			$_SESSION['approved-message'] = '“' . $artwork->Name . '” approved.';
+			$_SESSION['approved-artwork-id'] = $artwork->ArtworkId;
 			break;
 		case 'declined':
-			$_SESSION['declined-message'] = '“' . $artwork->Name . '” declined.';
+			$_SESSION['declined-artwork-id'] = $artwork->ArtworkId;
 			break;
 	}
 


### PR DESCRIPTION
This is useful because after approving an artwork, there's not an easy way to get to the public, shareable link of that artwork.

Here's what the new approved message looks like:

![Screenshot 2023-10-15 9 46 23 PM](https://github.com/standardebooks/web/assets/136965/86cc6a86-9712-4661-aba0-3fd6aeb85315)

where the link points to `/artworks/john-singer-sargent/oyster-gathering`.

The declined message is unchanged:

![Screenshot 2023-10-15 10 03 28 PM](https://github.com/standardebooks/web/assets/136965/5c37c2f5-850d-4218-b852-485ca8612248)

For the declined message, I considered adding a link to `/admin/artworks/<artwork-id>`, but decided not to.