### PR TITLE
Artist::DeleteIfUnused() is unused, so delete it

### DIFF
--- a/lib/Artist.php
+++ b/lib/Artist.php
@@ -140,21 +140,6 @@ class Artist extends PropertiesBase{
 		', [$this->ArtistId]);
 	}
 
-	public function DeleteIfUnused(): void{
-		Db::Query('
-			DELETE
-			FROM Artists
-			WHERE ArtistId NOT IN (SELECT ArtistId FROM Artworks)
-			  AND ArtistId = ?
-		', [$this->ArtistId]);
-		Db::Query('
-			DELETE
-			FROM AlternateSpellings
-			WHERE ArtistId NOT IN (SELECT ArtistId FROM Artworks)
-			  AND ArtistId = ?
-		', [$this->ArtistId]);
-	}
-
 	/**
 	 * @return array<Artist>
 	 */


### PR DESCRIPTION
b758ed4 removed the call to it. Also, with Artist::GetOrCreate() we're robust against creating duplicate artists, so an unused artist from a previous error will be reused when the user retries.