### PR TITLE
Update Docker Image to Ubuntu 22.04 and PHP 8.1

### DIFF
--- a/vms/docker/Dockerfile
+++ b/vms/docker/Dockerfile
@@ -1,23 +1,43 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip apache2 apache2-utils libfcgi0ldbl task-spooler libaprutil1-dbd-mysql attr libapache2-mod-xsendfile
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y sudo imagemagick openjdk-8-jre python3 pip calibre
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Avoid user interaction with tzdata when installing packages
+ENV DEBIAN_FRONTEND=noninteractive
 
+# Install dependencies and required PHP extensions
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata apt-utils composer \
+    php8.1-fpm php8.1-cli php8.1-gd php8.1-xml php8.1-apcu \
+    php8.1-mbstring php8.1-intl php8.1-curl php8.1-zip apache2 apache2-utils \
+    libfcgi0ldbl task-spooler libaprutil1-dbd-mysql attr libapache2-mod-xsendfile && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install other necessary packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends sudo imagemagick openjdk-8-jre-headless python3 python3-pip calibre && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Python package for standardebooks
 RUN pip install standardebooks
 
-RUN sudo addgroup committers
-RUN sudo adduser se
-RUN sudo usermod -g committers se
+# Create group and user for standardebooks
+RUN groupadd committers && \
+    useradd -m -g committers se && \
+    passwd -d se # Disable password for user 'se'
 
-RUN mkdir -p /standardebooks.org/web
-RUN mkdir /var/log/local
+# Create necessary directories
+RUN mkdir -p /standardebooks.org/web && \
+    mkdir /var/log/local
 
+# Enable Apache modules
 RUN a2enmod headers expires ssl rewrite proxy proxy_fcgi authn_dbd authn_socache
 
-# Disable opcaching for dynamic PHP reloading
-RUN echo "opcache.enable=0" >> /etc/php/7.4/fpm/php.ini
+# Disable opcode caching for dynamic PHP reloading and update ini file for PHP 8.1
+RUN echo "opcache.enable=0" >> /etc/php/8.1/fpm/php.ini
 
+# Expose port for https
 EXPOSE 443
+
+# Set entrypoint
 ENTRYPOINT ["/standardebooks.org/web/vms/docker/start-server.sh"]

--- a/vms/docker/start-server.sh
+++ b/vms/docker/start-server.sh
@@ -1,19 +1,43 @@
 #!/bin/sh
 
+# Generate SSL certificate if it doesn't exist
 if [ ! -f /standardebooks.org/web/config/ssl/standardebooks.test.crt ]; then
 	openssl req -x509 -nodes -days 99999 -newkey rsa:4096 -subj "/CN=standardebooks.test" -keyout /standardebooks.org/web/config/ssl/standardebooks.test.key -sha256 -out /standardebooks.org/web/config/ssl/standardebooks.test.crt
 fi
 
 cd /standardebooks.org/web
+
+# Update to required PHP version here if necessary
+
+# Run Composer install.
+# Note that the PHP version should be compatible with the packages in the composer.lock file.
 composer install
 
-ln -s /standardebooks.org/web/config/apache/standardebooks.test.conf /etc/apache2/sites-available/
-ln -s /standardebooks.org/web/config/php/fpm/standardebooks.org.ini /etc/php/*/cli/conf.d/
-ln -s /standardebooks.org/web/config/php/fpm/standardebooks.org.ini /etc/php/*/fpm/conf.d/
-ln -s /standardebooks.org/web/config/php/fpm/standardebooks.test.conf /etc/php/*/fpm/pool.d/
-a2ensite standardebooks.test
-service apache2 start
-service php7.4-fpm restart
+# Create symlink after checking if it already exists or removing the existing one
+create_symlink() {
+	target=$1
+	link=$2
+
+	if [ -L "$link" ]; then # Check if symlink already exists.
+		echo "Symlink $link already exists; skipping."
+	else
+		ln -s "$target" "$link"
+	fi
+}
+
+create_symlink /standardebooks.org/web/config/apache/standardebooks.test.conf /etc/apache2/sites-available/standardebooks.test.conf
+create_symlink /standardebooks.org/web/config/php/fpm/standardebooks.org.ini /etc/php/8.1/cli/conf.d/standardebooks.org.ini
+create_symlink /standardebooks.org/web/config/php/fpm/standardebooks.org.ini /etc/php/8.1/fpm/conf.d/standardebooks.org.ini
+create_symlink /standardebooks.org/web/config/php/fpm/standardebooks.test.conf /etc/php/8.1/fpm/pool.d/standardebooks.test.conf
+
+# Enable site only if it's not already enabled
+if ! a2query -s standardebooks.test > /dev/null; then
+	a2ensite standardebooks.test
+fi
+
+# Start or restart services
+service apache2 start || service apache2 reload
+service php8.1-fpm restart || service php8.1-fpm start
 
 # Keep the server available by holding open the container
 tail -f /dev/null


### PR DESCRIPTION
- Updated base image to Ubuntu 22.04.
- Upgraded to PHP 8.1.

Resolves issues with composer dependencies previously incompatible with PHP 7.1.