### PR TITLE
Update navigation footer script in Python

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -354,7 +354,7 @@ do
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s|<body([^>]*)>|<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}\">Back to ebook</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>|"
 
 		# Add a chapter navigation footer to each page
-		"${scriptsDir}"/inject-chapter-navigation-footer "${workDir}"/src/epub "${bookUrl}"
+		"${scriptsDir}"/inject-chapter-navigation-footer "${workDir}" "${bookUrl}"
 
 		# Adjust sponsored links in the colophon
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
 import html
+import os
 import se
-import se.se_epub
 import se.easy_xml
+import se.se_epub
 
 # Require arguments
 parser = argparse.ArgumentParser(description="A script to inject the navigation footer with links in the web version of a Standard Ebook")

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -31,6 +31,10 @@ spine_titles = [se.easy_xml.EasyXmlTree(open(file_path).read()).xpath("//head/ti
 # Make list of dicts containing title and relative path for each file
 chapter_links = [{"title": title, "path": path} for title, path in zip(spine_titles, rel_spine_paths)]
 
+# Create helper function for getting filename without extension
+def get_filename_without_extension(obj):
+	return os.path.splitext(obj["path"])[0] if obj else ""
+
 # Create footers
 for i, chapter_link in enumerate(chapter_links):
 	previousObj = chapter_links[i - 1] if i > 0 else None
@@ -38,11 +42,13 @@ for i, chapter_link in enumerate(chapter_links):
 
 	fileName = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
 
+	previous_link_filename, next_link_filename = [get_filename_without_extension(obj) for obj in [previousObj, nextObj]]
+
 	with open(fileName, "r") as file:
 		chapter = file.read()
 
-	previousLink = f"""<a href="{book_url}/{previousObj["path"]}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>""" if previousObj else ""
-	nextLink = f"""<a href="{book_url}/{nextObj["path"]}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>""" if nextObj else ""
+	previousLink = f"""<a href="{book_url}/{previous_link_filename}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>""" if previousObj else ""
+	nextLink = f"""<a href="{book_url}/{next_link_filename}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>""" if nextObj else ""
 
 	footer = f"<footer><ul><li>{previousLink}</li><li>{nextLink}</li></ul></footer>"
 	chapter = chapter.replace("</body>", f"{footer}</body>")

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -1,43 +1,53 @@
-#!/usr/bin/php
-<?
-if(count($argv) < 3){
-	print 'Expected usage: inject-chapter-navigation-footer <epubDirectory> <bookUrl>';
-	exit(1);
-}
-$epubDirectory = $argv[1];
-$bookUrl = $argv[2];
+#!/usr/bin/env python3
 
-// Parse the order of chapters from the table of contents.
-$doc = new DOMDocument();
-libxml_use_internal_errors(true); // Suppress warnings from output.
-$doc->loadHTMLFile($epubDirectory . '/toc.xhtml');
-libxml_clear_errors();
-$toc = $doc->getElementById('toc');
-if($toc){
-	$chapterLinks = array();
-	foreach($toc->getElementsByTagName('a') as $link){
-		$obj = new stdClass();
-		$obj->Path = $link->getAttribute('href');
-		$obj->Name = $link->textContent;
+import argparse
+import os
+import html
+import se
+import se.se_epub
+import se.easy_xml
 
-		// Only include links pointing to actual files (e.g. skip href="text/chapter-7#panawes-story").
-		if(file_exists($epubDirectory . '/' . $obj->Path . '.xhtml')){
-			$chapterLinks[] = $obj;
-		}
-	}
+# Require arguments
+parser = argparse.ArgumentParser(description='A script to inject the navigation footer with links in the web version of a Standard Ebook')
+parser.add_argument('ebook_dir', type=str, help='Path to the main directory of the ebook') # No trailing "/" on this path
+parser.add_argument('book_url', type=str, help='The ebook URL') # No trailing "/" on this link
+args = parser.parse_args()
 
-	for($i = 0; $i < count($chapterLinks); $i++){
-		$previousObj = $i > 0 ? $chapterLinks[$i - 1] : null;
-		$nextObj = $i < count($chapterLinks) - 1 ? $chapterLinks[$i + 1] : null;
+ebook_dir = args.ebook_dir
+book_url = args.book_url
 
-		$fileName = $epubDirectory . '/' . $chapterLinks[$i]->Path . '.xhtml';
-		$chapter = file_get_contents($fileName);
-		// Inject the navigation footer.
-		$previousLink = $previousObj ? sprintf('<a href="%s" rel="prev"><i>Previous:</i> %s</a>', $bookUrl . '/' . $previousObj->Path, htmlspecialchars($previousObj->Name)) : '';
-		$nextLink = $nextObj ? sprintf('<a href="%s" rel="next"><i>Next:</i> %s</a>', $bookUrl . '/' . $nextObj->Path, htmlspecialchars($nextObj->Name)) : '';
-		$footer = sprintf('<footer><ul><li>%s</li><li>%s</li></ul></footer>', $previousLink, $nextLink);
-		$chapter = str_replace('</body>', $footer . '</body>', $chapter);
-		file_put_contents($fileName, $chapter);
-	}
-}
-?>
+# Make an instance of the SeEpub class so we can use helper functions to easily get spine
+se_epub = se.se_epub.SeEpub(ebook_dir)
+
+# Get spine paths
+spine_paths = se_epub.spine_file_paths
+
+# Make sure spine paths are of the form "text/chapter-1.xhtml", with no leading "/"
+rel_spine_paths = [
+    '/'.join(str(path).split('/')[str(path).split('/').index('text'):]).lstrip('/') for path in spine_paths
+]
+
+# Get titles from spine
+spine_titles = [se.easy_xml.EasyXmlTree(open(file_path).read()).xpath("//head/title/text()", True) for file_path in spine_paths]
+
+# Make list of dicts containing title and relative path for each file
+chapter_links = [{"title": title, "path": path} for title, path in zip(spine_titles, rel_spine_paths)]
+
+# Create footers
+for i, chapter_link in enumerate(chapter_links):
+    previousObj = chapter_links[i - 1] if i > 0 else None
+    nextObj = chapter_links[i + 1] if i < len(chapter_links) - 1 else None
+
+    fileName = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
+
+    with open(fileName, 'r') as file:
+        chapter = file.read()
+
+    previousLink = f'<a href="{book_url}/{previousObj["path"]}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>' if previousObj else ''
+    nextLink = f'<a href="{book_url}/{nextObj["path"]}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>' if nextObj else ''
+
+    footer = f'<footer><ul><li>{previousLink}</li><li>{nextLink}</li></ul></footer>'
+    chapter = chapter.replace('</body>', f'{footer}</body>')
+
+    with open(fileName, 'w') as file:
+        file.write(chapter)

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -32,26 +32,26 @@ spine_titles = [se.easy_xml.EasyXmlTree(open(file_path).read()).xpath("//head/ti
 chapter_links = [{"title": title, "path": path} for title, path in zip(spine_titles, rel_spine_paths)]
 
 # Create helper function for getting filename without extension
-def get_filename_without_extension(obj):
-	return os.path.splitext(obj["path"])[0] if obj else ""
+def get_filename_without_extension(dict_with_path):
+	return os.path.splitext(dict_with_path["path"])[0] if dict_with_path else ""
 
 # Create footers
 for i, chapter_link in enumerate(chapter_links):
-	previousObj = chapter_links[i - 1] if i > 0 else None
-	nextObj = chapter_links[i + 1] if i < len(chapter_links) - 1 else None
+	previous_dict = chapter_links[i - 1] if i > 0 else None
+	next_dict = chapter_links[i + 1] if i < len(chapter_links) - 1 else None
 
-	fileName = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
+	file_path = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
 
-	previous_link_filename, next_link_filename = [get_filename_without_extension(obj) for obj in [previousObj, nextObj]]
+	previous_link_filename, next_link_filename = [get_filename_without_extension(chapter_dict) for chapter_dict in [previous_dict, next_dict]]
 
-	with open(fileName, "r") as file:
+	with open(file_path, "r") as file:
 		chapter = file.read()
 
-	previousLink = f"""<a href="{book_url}/{previous_link_filename}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>""" if previousObj else ""
-	nextLink = f"""<a href="{book_url}/{next_link_filename}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>""" if nextObj else ""
+	previous_link = f"""<a href="{book_url}/{previous_link_filename}" rel="prev"><i>Previous:</i> {html.escape(previous_dict["title"])}</a>""" if previous_dict else ""
+	next_link = f"""<a href="{book_url}/{next_link_filename}" rel="next"><i>Next:</i> {html.escape(next_dict["title"])}</a>""" if next_dict else ""
 
-	footer = f"<footer><ul><li>{previousLink}</li><li>{nextLink}</li></ul></footer>"
+	footer = f"<footer><ul><li>{previous_link}</li><li>{next_link}</li></ul></footer>"
 	chapter = chapter.replace("</body>", f"{footer}</body>")
 
-	with open(fileName, "w") as file:
+	with open(file_path, "w") as file:
 		file.write(chapter)

--- a/scripts/inject-chapter-navigation-footer
+++ b/scripts/inject-chapter-navigation-footer
@@ -8,9 +8,9 @@ import se.se_epub
 import se.easy_xml
 
 # Require arguments
-parser = argparse.ArgumentParser(description='A script to inject the navigation footer with links in the web version of a Standard Ebook')
-parser.add_argument('ebook_dir', type=str, help='Path to the main directory of the ebook') # No trailing "/" on this path
-parser.add_argument('book_url', type=str, help='The ebook URL') # No trailing "/" on this link
+parser = argparse.ArgumentParser(description="A script to inject the navigation footer with links in the web version of a Standard Ebook")
+parser.add_argument("ebook_dir", type=str, help="Path to the main directory of the ebook") # No trailing "/" on this path
+parser.add_argument("book_url", type=str, help="The ebook URL") # No trailing "/" on this link
 args = parser.parse_args()
 
 ebook_dir = args.ebook_dir
@@ -23,9 +23,7 @@ se_epub = se.se_epub.SeEpub(ebook_dir)
 spine_paths = se_epub.spine_file_paths
 
 # Make sure spine paths are of the form "text/chapter-1.xhtml", with no leading "/"
-rel_spine_paths = [
-    '/'.join(str(path).split('/')[str(path).split('/').index('text'):]).lstrip('/') for path in spine_paths
-]
+rel_spine_paths = ["/".join(str(path).split("/")[str(path).split("/").index("text"):]).lstrip("/") for path in spine_paths]
 
 # Get titles from spine
 spine_titles = [se.easy_xml.EasyXmlTree(open(file_path).read()).xpath("//head/title/text()", True) for file_path in spine_paths]
@@ -35,19 +33,19 @@ chapter_links = [{"title": title, "path": path} for title, path in zip(spine_tit
 
 # Create footers
 for i, chapter_link in enumerate(chapter_links):
-    previousObj = chapter_links[i - 1] if i > 0 else None
-    nextObj = chapter_links[i + 1] if i < len(chapter_links) - 1 else None
+	previousObj = chapter_links[i - 1] if i > 0 else None
+	nextObj = chapter_links[i + 1] if i < len(chapter_links) - 1 else None
 
-    fileName = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
+	fileName = os.path.join(ebook_dir, "src/epub", chapter_link["path"])
 
-    with open(fileName, 'r') as file:
-        chapter = file.read()
+	with open(fileName, "r") as file:
+		chapter = file.read()
 
-    previousLink = f'<a href="{book_url}/{previousObj["path"]}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>' if previousObj else ''
-    nextLink = f'<a href="{book_url}/{nextObj["path"]}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>' if nextObj else ''
+	previousLink = f"""<a href="{book_url}/{previousObj["path"]}" rel="prev"><i>Previous:</i> {html.escape(previousObj["title"])}</a>""" if previousObj else ""
+	nextLink = f"""<a href="{book_url}/{nextObj["path"]}" rel="next"><i>Next:</i> {html.escape(nextObj["title"])}</a>""" if nextObj else ""
 
-    footer = f'<footer><ul><li>{previousLink}</li><li>{nextLink}</li></ul></footer>'
-    chapter = chapter.replace('</body>', f'{footer}</body>')
+	footer = f"<footer><ul><li>{previousLink}</li><li>{nextLink}</li></ul></footer>"
+	chapter = chapter.replace("</body>", f"{footer}</body>")
 
-    with open(fileName, 'w') as file:
-        file.write(chapter)
+	with open(fileName, "w") as file:
+		file.write(chapter)


### PR DESCRIPTION
deploy-ebook-to-www: 

- In order to make an instance of the SeEpub class in inject-chapter-navigation-footer we need the main directory of the ebook not workDir/src/epub.

inject-chapter-navigation-footer: 
- I couldn't run the script using pipx, so I had to run it using standardebooks installed with pip. The se package doesn't seem installable editably with pip, so I couldn't use any edits to tools I'd made; originally I did have a function in formatting.py as you suggested.

- A function for extracting titles from the spine could easily be added to formatting.py, but 1) I won't be able to test it, unless there is some way I'm missing to run the script with pipx or use a pip installation editably and 2) it's only one line here (line 26, setting value of rel_spine_paths) so maybe it's not worth adding anyway.

- I tested this by simply running it on a single ebook and inspecting the HTML output, which appears the same as that generated by the PHP script, only without the error for poetry collections.

- Currently the arguments cannot have trailing "/". This seems to conform to the current values of bookUrl and workDir in deploy-ebook-to-www.

- Here is the command I used to run it (obviously alter paths as required if also running it in this way):

`python3 web/scripts/inject-chapter-navigation-footer "ebooks-dir/robert-frost_new-hampshire" "https://standardebooks.org/ebooks/robert-frost/new-hampshire"`