### PR TITLE
Add check for rsvg-convert

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -130,6 +130,7 @@ fi
 require "convert" "Try: apt-get install imagemagick"
 require "git" "Try: apt-get install git"
 require "php" "Try: apt-get install php-cli"
+require "rsvg-convert" "Try: apt-get install librsvg2-bin"
 require "se" "Read: https://standardebooks.org/tools"
 
 # cavif is compiled via Cargo: https://github.com/kornelski/cavif-rs


### PR DESCRIPTION
`scripts/deploy-ebook-to-www` relies on `rsvg-convert` which doesn't seem to be a documented dependency:

```sh
➜  web git:(master) ./scripts/deploy-ebook-to-www ../ebooks/david-lindsay_a-voyage-to-arcturus.git
./scripts/deploy-ebook-to-www: line 250: rsvg-convert: command not found
```

This PR adds a check for it and suggests installing `python3-sphinxcontrib.svg2pdfconverter` to provide it.