### PR TITLE
Add grid layouts for smaller screens to /artwork grid

### DIFF
--- a/www/css/artwork.css
+++ b/www/css/artwork.css
@@ -276,3 +276,23 @@ form div.footer{
 		grid-column: 1;
 	}
 }
+
+@media(max-width: 1020px){
+	main > section > ol.artwork-list{
+		grid-template-columns: repeat(3, 1fr);
+		gap: 3rem;
+	}
+}
+
+@media(max-width: 760px){
+	main > section > ol.artwork-list{
+		grid-template-columns: repeat(2, 1fr);
+		gap: 3rem;
+	}
+}
+
+@media(max-width: 480px){
+	main > section > ol.artwork-list{
+		grid-template-columns: repeat(1, 1fr);
+	}
+}


### PR DESCRIPTION
With the new grid it was a bit difficult to view the /artworks page on mobile. The filter controls still overflow but it is usable.

fyi @colagrosso in case you are working in this area.

![screenshot-1](https://github.com/standardebooks/web/assets/34031005/552d06d8-a762-4026-b2f9-d022c5986f12)
![screenshot-2](https://github.com/standardebooks/web/assets/34031005/184d08a1-f92f-4d71-a8c9-ab1a2bb0ef26)
