### PR TITLE
Add grid layouts for smaller screens to /artwork filter form

### DIFF
--- a/www/artworks/index.php
+++ b/www/artworks/index.php
@@ -90,7 +90,7 @@ if($perPage !== COVER_ARTWORK_PER_PAGE){
 			<label class="search">Keywords
 				<input type="search" name="query" value="<?= Formatter::ToPlainText($query) ?>"/>
 			</label>
-			<label>
+			<label class="sort">
 				<span>Sort</span>
 				<span>
 					<select name="sort">

--- a/www/css/artwork.css
+++ b/www/css/artwork.css
@@ -76,12 +76,24 @@ form[action^="/artworks/"]{
 }
 
 .artworks form[action="/artworks"]{
-	align-items: end;
 	display: grid;
 	grid-gap: 1rem;
-	grid-template-columns: auto auto auto auto 1fr;
+	grid-template-columns: auto auto auto 1fr;
 	margin-top: 2rem;
 	max-width: calc(100% - 2rem);
+}
+
+.artworks form[action="/artworks"] button{
+	justify-self: end;
+	margin-top: 1.4rem;
+}
+
+.artworks form[action="/artworks"] label.search{
+	grid-column: span 3;
+}
+
+.artworks form[action="/artworks"] label.sort{
+	grid-column: span 2;
 }
 
 form[action="/artworks"] > fieldset{
@@ -289,10 +301,33 @@ form div.footer{
 		grid-template-columns: repeat(2, 1fr);
 		gap: 3rem;
 	}
+
+	.artworks form[action="/artworks"]{
+		grid-template-columns: auto 1fr auto;
+	}
+
+	.artworks form[action="/artworks"] label.search,
+	.artworks form[action="/artworks"] label.sort{
+		grid-column: span 2;
+	}
+
+	.artworks form[action="/artworks"] button{
+		grid-column: span 3;
+	}
 }
 
 @media(max-width: 480px){
 	main > section > ol.artwork-list{
-		grid-template-columns: repeat(1, 1fr);
+		grid-template-columns: auto;
+	}
+
+	.artworks form[action="/artworks"]{
+		grid-template-columns: auto;
+	}
+
+	.artworks form[action="/artworks"] label.sort,
+	.artworks form[action="/artworks"] label.search,
+	.artworks form[action="/artworks"] button{
+		grid-column: auto;
 	}
 }


### PR DESCRIPTION
As discussed, updates to the filter controls on `/artworks` for smaller screens. Screenshots below;

![screenshot-fullscreen](https://github.com/standardebooks/web/assets/34031005/59d95a64-5959-4601-9804-c4cae1ee1442)
![screenshot-tablet](https://github.com/standardebooks/web/assets/34031005/f18c11e1-2a9c-4be3-9e7c-852895c92fbd)
![screenshot-phone](https://github.com/standardebooks/web/assets/34031005/6752a3b5-3b97-4cd7-b1aa-7361c56b808f)
