### PR TITLE
Default status is Unverified when posting artwork

### DIFF
--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -31,7 +31,7 @@ try{
 		$artwork->CompletedYear = HttpInput::Int(POST, 'artwork-year');
 		$artwork->CompletedYearIsCirca = HttpInput::Bool(POST, 'artwork-year-is-circa', false) ?? false;
 		$artwork->Tags = HttpInput::Str(POST, 'artwork-tags', false) ?? [];
-		$artwork->Status = HttpInput::Str(POST, 'artwork-status', false);
+		$artwork->Status = HttpInput::Str(POST, 'artwork-status', false) ?? ArtworkStatus::Unverified;
 		$artwork->EbookWwwFilesystemPath = HttpInput::Str(POST, 'artwork-ebook-www-filesystem-path', false);
 		$artwork->SubmitterUserId = $GLOBALS['User']->UserId ?? null;
 		$artwork->IsPublishedInUs = HttpInput::Bool(POST, 'artwork-is-published-in-us', false);


### PR DESCRIPTION
Without this change, users that have `CanUploadArtwork` but not `CanReviewOwnArtwork` would get an `InvalidPermissionsException` because `Status` is `null` on this line:

https://github.com/standardebooks/web/blob/206e125da79357adc08d9e54857aceb880b0b829/www/artworks/post.php#L48

Before 531e3600eadd3d9e79d5f2b4b19d762ba60ec40a, the line read:

```php
$artwork->Status = HttpInput::Str(POST, 'artwork-status', false, COVER_ARTWORK_STATUS_UNVERIFIED);
```