### PR TITLE
Library::FilterArtwork(): Move sort logic to SQL, condense status condition

### DIFF
--- a/lib/Library.php
+++ b/lib/Library.php
@@ -180,9 +180,6 @@ class Library{
 		elseif($status == 'all-admin'){
 			$statusCondition = 'true';
 		}
-		elseif($status == 'in-use'){
-			$statusCondition = 'EbookWwwFilesystemPath is not null';
-		}
 		elseif($status == 'all-submitter' && $submitterUserId !== null){
 			$statusCondition = 'Status = ? or (Status = ? and SubmitterUserId = ?)';
 			$params[] = ArtworkStatus::Approved->value;
@@ -193,6 +190,10 @@ class Library{
 			$statusCondition = 'Status = ? and SubmitterUserId = ?';
 			$params[] = ArtworkStatus::Unverified->value;
 			$params[] = $submitterUserId;
+		}
+		elseif($status == 'in-use'){
+			$statusCondition = 'Status = ? and EbookWwwFilesystemPath is not null';
+			$params[] = ArtworkStatus::Approved->value;
 		}
 		elseif($status == ArtworkStatus::Approved->value){
 			$statusCondition = 'Status = ? and EbookWwwFilesystemPath is null';

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -204,17 +204,18 @@ class Library{
 			$params[] = $status;
 		}
 
-		$orderBy = 'Created desc';
+		$orderBy = 'art.Created desc';
 		if($sort == SORT_COVER_ARTIST_ALPHA){
-			$orderBy = 'Name';
+			$orderBy = 'a.Name';
 		}
 		elseif($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){
-			$orderBy = 'CompletedYear desc';
+			$orderBy = 'art.CompletedYear desc';
 		}
 
 		$artworks = Db::Query('
-			SELECT *
-			from Artworks
+			SELECT art.*
+			from Artworks art
+			inner join Artists a using (ArtistId)
 			where ' . $statusCondition .
 			' order by ' . $orderBy, $params, 'Artwork');
 

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -170,57 +170,55 @@ class Library{
 		// "unverified-submitter": Show unverified artwork from the submitter
 		// "in-use": Show only in-use artwork
 
-		$artworks = [];
+		$orderBy = 'Created desc';
+		if($sort == SORT_COVER_ARTIST_ALPHA){
+			$orderBy = 'Name';
+		}
+		elseif($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){
+			$orderBy = 'CompletedYear desc';
+		}
+
+		$statusCondition = '';
+		$params = [];
 
 		if($status === null || $status == 'all'){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where Status in (?)', [ArtworkStatus::Approved->value], 'Artwork');
+			$statusCondition = 'Status = ?';
+			$params[] = ArtworkStatus::Approved->value;
 		}
 		elseif($status == 'all-admin'){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks', [], 'Artwork');
+			$statusCondition = 'true';
 		}
 		elseif($status == 'in-use'){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where EbookWwwFilesystemPath is not null
-				', [], 'Artwork');
+			$statusCondition = 'EbookWwwFilesystemPath is not null';
 		}
 		elseif($status == 'all-submitter' && $submitterUserId !== null){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where Status = ?
-				or (Status = ? and SubmitterUserId = ?)', [ArtworkStatus::Approved->value, ArtworkStatus::Unverified->value, $submitterUserId], 'Artwork');
+			$statusCondition = 'Status = ? or (Status = ? and SubmitterUserId = ?)';
+			$params[] = ArtworkStatus::Approved->value;
+			$params[] = ArtworkStatus::Unverified->value;
+			$params[] = $submitterUserId;
 		}
 		elseif($status == 'unverified-submitter' && $submitterUserId !== null){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where Status = ? and SubmitterUserId = ?', [ArtworkStatus::Unverified->value, $submitterUserId], 'Artwork');
+			$statusCondition = 'Status = ? and SubmitterUserId = ?';
+			$params[] = ArtworkStatus::Unverified->value;
+			$params[] = $submitterUserId;
 		}
 		elseif($status == ArtworkStatus::Approved->value){
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where Status = ? and EbookWwwFilesystemPath is null', [ArtworkStatus::Approved->value], 'Artwork');
+			$statusCondition = 'Status = ? and EbookWwwFilesystemPath is null';
+			$params[] = ArtworkStatus::Approved->value;
 		}
 		else{
-			$artworks = Db::Query('
+			$statusCondition = 'Status = ?';
+			$params[] = $status;
+		}
+
+		$artworks = [];
+			$artworks = Db::Query("
 				SELECT *
 				from Artworks
-				where Status = ?', [$status], 'Artwork');
-		}
+				where $statusCondition
+				order by $orderBy", $params, 'Artwork');
 
 		$matches = $artworks;
-
-		if($sort === null){
-			$sort = SORT_COVER_ARTWORK_CREATED_NEWEST;
-		}
 
 		if($query !== null){
 			$filteredMatches = [];
@@ -234,52 +232,6 @@ class Library{
 			$matches = $filteredMatches;
 		}
 
-		switch($sort){
-			case SORT_COVER_ARTIST_ALPHA:
-				$collator = Collator::create('en_US'); // Used for sorting letters with diacritics like in artist names
-				if($collator === null){
-					usort($matches, function($a, $b){
-						return strcmp(mb_strtolower($a->Artist->Name), mb_strtolower($b->Artist->Name));
-					});
-				}
-				else{
-					usort($matches, function($a, $b) use($collator){
-						return $collator->compare($a->Artist->Name, $b->Artist->Name);
-					});
-				}
-
-				break;
-
-			case SORT_COVER_ARTWORK_CREATED_NEWEST:
-				usort($matches, function($a, $b){
-					if($a->Created > $b->Created){
-						return -1;
-					}
-					elseif($a->Created == $b->Created){
-						return 0;
-					}
-					else{
-						return 1;
-					}
-				});
-
-				break;
-
-			case SORT_COVER_ARTWORK_COMPLETED_NEWEST:
-				usort($matches, function($a, $b){
-					if($a->CompletedYear > $b->CompletedYear){
-						return -1;
-					}
-					elseif($a->CompletedYear == $b->CompletedYear){
-						return 0;
-					}
-					else{
-						return 1;
-					}
-				});
-
-				break;
-		}
 
 		return $matches;
 	}

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -212,12 +212,11 @@ class Library{
 			$orderBy = 'CompletedYear desc';
 		}
 
-		$artworks = [];
-			$artworks = Db::Query('
-				SELECT *
-				from Artworks
-				where ' . $statusCondition .
-				' order by ' . $orderBy, $params, 'Artwork');
+		$artworks = Db::Query('
+			SELECT *
+			from Artworks
+			where ' . $statusCondition .
+			' order by ' . $orderBy, $params, 'Artwork');
 
 		$matches = $artworks;
 

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -170,14 +170,6 @@ class Library{
 		// "unverified-submitter": Show unverified artwork from the submitter
 		// "in-use": Show only in-use artwork
 
-		$orderBy = 'Created desc';
-		if($sort == SORT_COVER_ARTIST_ALPHA){
-			$orderBy = 'Name';
-		}
-		elseif($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){
-			$orderBy = 'CompletedYear desc';
-		}
-
 		$statusCondition = '';
 		$params = [];
 
@@ -211,12 +203,20 @@ class Library{
 			$params[] = $status;
 		}
 
+		$orderBy = 'Created desc';
+		if($sort == SORT_COVER_ARTIST_ALPHA){
+			$orderBy = 'Name';
+		}
+		elseif($sort == SORT_COVER_ARTWORK_COMPLETED_NEWEST){
+			$orderBy = 'CompletedYear desc';
+		}
+
 		$artworks = [];
-			$artworks = Db::Query("
+			$artworks = Db::Query('
 				SELECT *
 				from Artworks
-				where $statusCondition
-				order by $orderBy", $params, 'Artwork');
+				where ' . $statusCondition .
+				' order by ' . $orderBy, $params, 'Artwork');
 
 		$matches = $artworks;
 
@@ -231,7 +231,6 @@ class Library{
 
 			$matches = $filteredMatches;
 		}
-
 
 		return $matches;
 	}


### PR DESCRIPTION
This is just a preliminary refactor because I haven't added the filter logic to the SQL yet, but I wanted to check if you thought I was on the right track with the sort logic and handling the status. The goal is to have just one `Db::Query()` instead of one in each of the `if`/`elseif` branches because the SQL is about to get gnarlier.