### PR TITLE
Fix searching for words adjacent to an underscore in EbookWwwFilesystemPath

### DIFF
--- a/lib/Library.php
+++ b/lib/Library.php
@@ -237,7 +237,7 @@ class Library{
 			  left join Tags t using (TagId)
 			where ' . $statusCondition . '
 			  and (art.Name regexp ?
-                          or art.EbookWwwFilesystemPath regexp ?
+                          or replace(art.EbookWwwFilesystemPath, "_", " ") regexp ?
 			  or a.Name regexp ?
 			  or aan.Name regexp ?
 			  or t.Name regexp ?)


### PR DESCRIPTION
The underscore in `EbookWwwFilesystemPath` is a problem for the word boundary regex because MySQL treats underscores as part of a word, not a boundary.

Consider this ebook path:

`daniel-defoe_moll-flanders`

These searches don't work, because the words are adjacent to the underscore in the ebook path:

moll: https://standardebooks.org/artworks?status=all&query=moll
defoe: https://standardebooks.org/artworks?status=all&query=defoe

but these searches do work:

flanders: https://standardebooks.org/artworks?status=all&query=flanders
daniel: https://standardebooks.org/artworks?status=all&query=daniel

We could apply a different regex to `EbookWwwFilesystemPath`, but I like keeping the regex the same and just removing the underscore from `EbookWwwFilesystemPath` on the fly in the query.