### PR TITLE
Set artist name length to 255

### DIFF
--- a/config/sql/se/Artists.sql
+++ b/config/sql/se/Artists.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `Artists` (
   `ArtistId` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `Name` varchar(191) NOT NULL,
+  `Name` varchar(255) NOT NULL,
   `UrlName` varchar(255) NOT NULL,
   `DeathYear` smallint unsigned NULL,
   `Created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
More background than you need: Back in the early days of `config/sql/se/Artists.sql`, I was having trouble creating the `Artists` table because I was getting a weird MySQL error that the `Name` field was too long to index. By trial-and-error, I found that changing it from 255 to 191 would allow me to create the table. We made several improvements to that table, and when I tried it now from scratch 255 works fine.

Fast forward to today: I compounded the mistake by also setting `COVER_ARTWORK_MAX_STRING_LENGTH` to 191. Commit 03821d6 updates `COVER_ARTWORK_MAX_STRING_LENGTH` to 250, but that leaves a gap where there could be a crash for artist names between 192-250 characters:

1. Under 192: Works as expected
2. 192-250: Crashes with this PHP error:

```
NOTICE: PHP message: PHP Fatal error:  Uncaught PDOException: SQLSTATE[22001]: String data, right truncated: 1406 
Data too long for column 'Name' at row 1 in /standardebooks.org/web/lib/DbConnection.php:160
```
3. Over 250: Shows validation error to the user `String too long: Artist Name`

You can fix the column in place via:

```sql
ALTER TABLE Artists MODIFY COLUMN Name VARCHAR(255);
```

