### PR TITLE
Update AlternateTitle to parse dcterms:alternate

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -218,7 +218,7 @@ class Ebook{
 
 		$this->FullTitle = $this->NullIfEmpty($xml->xpath('/package/metadata/dc:title[@id="fulltitle"]'));
 
-		$this->AlternateTitle = $this->NullIfEmpty($xml->xpath('/package/metadata/meta[@property="se:alternate-title"]'));
+		$this->AlternateTitle = $this->NullIfEmpty($xml->xpath('/package/metadata/meta[@property="dcterms:alternate"][@refines="#title"]'));
 
 		$date = $xml->xpath('/package/metadata/dc:date') ?: [];
 		if($date !== false && sizeof($date) > 0){


### PR DESCRIPTION
I noticed all the `AlternateTitle` fields in my Ebook DB were null. This fixes the parsing to match the 2022 change in https://github.com/standardebooks/manual/commit/3842a03286d270dedd2eb996454ae41db6f17475 and affected ebooks, and the DB entries are correct now.