### PR TITLE
Shorten regex to find probable british2american errors

### DIFF
--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -298,7 +298,7 @@ proceed to seal up my confession, I bring the life of that unhappy Henry Jekyll 
 				<p><code class="bash"><b>se</b> british2american</code> attempts to automate the conversion. Your work must already be typogrified (one of the previous steps in this guide) for the script to work.</p><code class="terminal"><span><b>se</b> british2american <u>.</u></span></code>
 				<p>While <code class="bash"><b>se</b> british2american</code> tries its best, thanks to the quirkiness of English punctuation rules it’ll invariably mess some stuff up. Proofreading is required after running the conversion.</p>
 				<aside class="tip">
-					<p>This regex is useful for spotting incorrectly converted quotes next to em dashes: <code class="regex">“[^”‘]+’⁠—(?=[^”]*?&lt;/p&gt;;)</code></p>
+					<p>This regex is useful for spotting incorrectly converted quotes next to em dashes: <code class="regex">“[^”‘]+’⁠—</code></p>
 				</aside>
 				<p>After you’ve run the conversion, do another commit.</p><code class="terminal"><span><b>git</b> commit -am <i>"Convert from British-style quotation to American style"</i></span></code>
 			</li>


### PR DESCRIPTION
The regex for finding issues after `british2american` is too restrictive; I've never had it find anything, but I always have errors after running it. The problem is what comes after the em-dash.

It looks for a ldquo followed by text and then a rsquo and em-dash; this is perfect so far. When this happens, it's almost always a break in a piece of dialog, e.g. "He said something’—some kind of aside—“and then he said something else.”

But the rest of the regex after the em-dash has a negative lookahead assertion for a rdquo, which is almost always present, so it doesn't match any of them. Thus, in something I'm working on now, the Step-by-Step regex didn't find anything, but the one in the PR found six valid errors.

It's _possible_ for the above to show a false-positive, but in my experience they're few and far between, and this is one of the cases where IMO we want to find as much as possible, so highlighting the occasional false-positive that can be ignored is preferable to missing a bunch of actual errors, which is the current situation.

(As another possible improvement, maybe we want to make this an `se interactive-replace` string they can just cut-and-paste, so they can work through them interactively?)