### PR TITLE
Workaround a bug in Safe-PHP that causes PHPStan errors

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -581,7 +581,7 @@ class Ebook{
 	// *******
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Validate(): void{
 		/** @throws void */
@@ -759,7 +759,7 @@ class Ebook{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	private function InsertTagStrings(): void{
 		$tags = [];
@@ -770,7 +770,7 @@ class Ebook{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	private function InsertLocSubjectStrings(): void{
 		$subjects = [];
@@ -1083,7 +1083,7 @@ class Ebook{
 	// ***********
 
 	/**
-	 * @throws \Exceptions\EbookNotFoundException
+	 * @throws Exceptions\EbookNotFoundException
 	 */
 	public static function GetByIdentifier(?string $identifier): Ebook{
 		if($identifier === null){

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -581,11 +581,12 @@ class Ebook{
 	// *******
 
 	/**
-	 * @throws \Exception
 	 * @throws \Exceptions\ValidationException
 	 */
 	public function Validate(): void{
+		/** @throws void */
 		$now = new DateTimeImmutable();
+
 		$error = new Exceptions\ValidationException();
 
 		if($this->Identifier == ''){
@@ -744,7 +745,7 @@ class Ebook{
 	}
 
 	/**
-	 * @throws \Exception
+	 * @throws Exceptions\ValidationException
 	 */
 	public function CreateOrUpdate(): void{
 		try{
@@ -1103,7 +1104,7 @@ class Ebook{
 	}
 
 	/**
-	 * @throws \Exception
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Create(): void{
 		$this->Validate();
@@ -1157,7 +1158,7 @@ class Ebook{
 	}
 
 	/**
-	 * @throws \Exception
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Save(): void{
 		$this->Validate();

--- a/lib/EbookTag.php
+++ b/lib/EbookTag.php
@@ -24,7 +24,7 @@ class EbookTag extends Tag{
 	// *******
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Validate(): void{
 		$error = new Exceptions\ValidationException();
@@ -39,7 +39,7 @@ class EbookTag extends Tag{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Create(): void{
 		$this->Validate();
@@ -52,7 +52,7 @@ class EbookTag extends Tag{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function GetByNameOrCreate(string $name): EbookTag{
 		$result = Db::Query('

--- a/lib/Exceptions/InvalidEbookCreatedDatetimeException.php
+++ b/lib/Exceptions/InvalidEbookCreatedDatetimeException.php
@@ -7,10 +7,8 @@ class InvalidEbookCreatedDatetimeException extends AppException{
 	/** @var string $message */
 	protected $message = 'Invalid EbookCreated datetime.';
 
-	/**
-	 * @throws \Exception
-	 */
 	public function __construct(DateTimeImmutable $createdDatetime){
+		/** @throws void */
 		$now = new DateTimeImmutable();
 		$this->message = 'Invalid EbookCreated datetime. ' . $createdDatetime->format('Y-m-d') . ' is not between ' . EBOOK_EARLIEST_CREATION_DATE->format('Y-m-d') . ' and ' . $now->format('Y-m-d') . '.';
 	}

--- a/lib/Exceptions/InvalidEbookUpdatedDatetimeException.php
+++ b/lib/Exceptions/InvalidEbookUpdatedDatetimeException.php
@@ -7,10 +7,8 @@ class InvalidEbookUpdatedDatetimeException extends AppException{
 	/** @var string $message */
 	protected $message = 'Invalid EbookUpdated datetime.';
 
-	/**
-	 * @throws \Exception
-	 */
 	public function __construct(DateTimeImmutable $updatedDatetime){
+		/** @throws void */
 		$now = new DateTimeImmutable();
 		$this->message = 'Invalid EbookUpdated datetime. ' . $updatedDatetime->format('Y-m-d') . ' is not between ' . EBOOK_EARLIEST_CREATION_DATE->format('Y-m-d') . ' and ' . $now->format('Y-m-d') . '.';
 	}

--- a/lib/LocSubject.php
+++ b/lib/LocSubject.php
@@ -3,7 +3,7 @@ class LocSubject extends Tag{
 	public int $LocSubjectId;
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Validate(): void{
 		$error = new Exceptions\ValidationException();
@@ -18,7 +18,7 @@ class LocSubject extends Tag{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function Create(): void{
 		$this->Validate();
@@ -31,7 +31,7 @@ class LocSubject extends Tag{
 	}
 
 	/**
-	 * @throws \Exceptions\ValidationException
+	 * @throws Exceptions\ValidationException
 	 */
 	public function GetByNameOrCreate(string $name): LocSubject{
 		$result = Db::Query('


### PR DESCRIPTION
Thanks for pointing this out in a [previous commit](https://github.com/standardebooks/web/commit/406eff56a904b8d3b5fd1ad6a55fae860e5e1330#r142337290) and sorry for not noticing the inline PHPDocs you already added to previous `Safe\DateTimeImmutable` instantiations. 

I added a second commit in this PR to remove some leading slashes I mistakenly put in some `@throws` statements.