### PR TITLE
When creating bare repos, clone with --mirror instead of --bare

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -97,7 +97,7 @@ while [ $# -gt 0 ]; do
 			shift 2
 			;;
 		-b|--bare)
-			bare="--bare"
+			bare="--mirror"
 			shift 1
 			;;
 		*)

--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -131,8 +131,8 @@ for item in ./*/; do
 		printf "Updating %s ... " "${item}"
 	fi
 
-    # if it's not a repository directory, skip it
-    git -C "${item}" rev-parse > /dev/null 2>&1 || continue
+	# if it's not a repository directory, skip it
+	git -C "${item}" rev-parse > /dev/null 2>&1 || continue
 
 	# this works whether the repository is bare or a working directory
 	if [ "${verbosity}" -lt 2 ]; then


### PR DESCRIPTION
I keep a directory of bare repositories, which I created by running `sync-ebooks -v -b` and regularly update with the same command.

Behind the scenes, `sync-ebooks` runs `git fetch -v` in each repository (whether bare or not). In a normal repository, this doesn't update the checked‐out `master` branch, but does update `remote/origin/master` and `remote/origin/HEAD`. In a bare repository, though, there are no remote branches, only the one branch `master`, which remains unchanged. I assume `git fetch` is bringing in newer commits, but without any references they are effectively inaccessible as far as I can tell. [(My not realizing this led to merge conflicts in a recent pull request.)](https://github.com/standardebooks/guy-de-maupassant_short-fiction_ernest-boyd_storm-jameson_jeffery-e-jeffery_lafcadio-hearn_m-walter-/pull/4)

We could change `sync-ebooks` to run `git fetch origin master:master`. In a bare repo, that does what I consider intuitive: `master` will be updated to point to the fetched commits. But checked‐out repos don’t play well with this command, so we would have to split the command paths for bare and non‐bare repos. (Besides making the code more complicated, a reason I consider this undesirable is that it would eliminate an undocumented but useful characteristic of `sync-ebooks`, that it will update both bare and checked‐out repositories present in the same directory.)

However, we can get this behavior in bare repos automatically by cloning with with `--mirror`. Doing so adds this line to the new repo’s Git config:

```
fetch = +refs/*:refs/*
```

With this `sync-ebooks`’ behavior for checked‐out repos is unchanged, while bare (now mirror) repos update their only branch, `master`, to the latest `master` commit in the origin, which I think is a more natural and useful behavior.