### PR TITLE
Implement OpenSearch feed search with FilterEbooks

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -1152,51 +1152,6 @@ class Ebook{
 		return null;
 	}
 
-	public function Contains(string $query): bool{
-		// When searching an ebook, we search the title, alternate title, author(s), SE tags, series data, and LoC tags.
-		// Also, if the ebook is shorts or poetry, search the ToC as well.
-
-		$searchString = $this->FullTitle ?? $this->Title;
-
-		$searchString .= ' ' . $this->AlternateTitle;
-
-		foreach($this->CollectionMemberships as $collectionMembership){
-			$searchString .= ' ' . $collectionMembership->Collection->Name;
-		}
-
-		foreach($this->Authors as $author){
-			$searchString .= ' ' . $author->Name;
-		}
-
-		foreach($this->Tags as $tag){
-			$searchString .= ' ' . $tag->Name;
-		}
-
-		foreach($this->LocSubjects as $subject){
-			$searchString .= ' ' . $subject->Name;
-		}
-
-		if($this->TocEntries !== null){
-			foreach($this->TocEntries as $item){
-				$searchString .= ' ' . $item;
-			}
-		}
-
-		// Remove diacritics and non-alphanumeric characters
-		$searchString = trim(preg_replace('|[^a-zA-Z0-9 ]|ius', ' ', Formatter::RemoveDiacritics($searchString)));
-		$query = trim(preg_replace('|[^a-zA-Z0-9 ]|ius', ' ', Formatter::RemoveDiacritics($query)));
-
-		if($query == ''){
-			return false;
-		}
-
-		if(mb_stripos($searchString, $query) !== false){
-			return true;
-		}
-
-		return false;
-	}
-
 	public function GenerateJsonLd(): string{
 		$output = new stdClass();
 		$output->{'@context'} = 'https://schema.org';

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -431,23 +431,6 @@ class Library{
 
 	/**
 	 * @return array<Ebook>
-	 * @throws Exceptions\AppException
-	 */
-	public static function Search(string $query): array{
-		$ebooks = Library::GetEbooks();
-		$matches = [];
-
-		foreach($ebooks as $ebook){
-			if($ebook->Contains($query)){
-				$matches[] = $ebook;
-			}
-		}
-
-		return $matches;
-	}
-
-	/**
-	 * @return array<Ebook>
 	 */
 	public static function GetEbooksFromFilesystem(?string $webRoot = WEB_ROOT): array{
 		$ebooks = [];

--- a/www/ebooks/opensearch.php
+++ b/www/ebooks/opensearch.php
@@ -11,8 +11,8 @@ print('<?xml version="1.0" encoding="utf-8"?>');
 	<OutputEncoding>UTF-8</OutputEncoding>
 	<InputEncoding>UTF-8</InputEncoding>
 	<Url type="application/xhtml+xml" template="<?= SITE_URL ?>/ebooks?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
-	<Url type="application/rss+xml" template="<?= SITE_URL ?>/feeds/rss/all?query={searchTerms}"/>
-	<Url type="application/atom+xml" template="<?= SITE_URL ?>/feeds/atom/all?query={searchTerms}"/>
-	<Url type="application/atom+xml;profile=opds-catalog;kind=acquisition" template="<?= SITE_URL ?>/feeds/opds/all?query={searchTerms}"/>
+	<Url type="application/rss+xml" template="<?= SITE_URL ?>/feeds/rss/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
+	<Url type="application/atom+xml" template="<?= SITE_URL ?>/feeds/atom/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
+	<Url type="application/atom+xml;profile=opds-catalog;kind=acquisition" template="<?= SITE_URL ?>/feeds/opds/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
 	<Query role="example" searchTerms="fiction" startPage="1" count="12"/>
 </OpenSearchDescription>

--- a/www/ebooks/opensearch.xml
+++ b/www/ebooks/opensearch.xml
@@ -8,8 +8,8 @@
 	<OutputEncoding>UTF-8</OutputEncoding>
 	<InputEncoding>UTF-8</InputEncoding>
 	<Url type="application/xhtml+xml" template="https://standardebooks.org/ebooks?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
-	<Url type="application/rss+xml" template="https://standardebooks.org/feeds/rss/all?query={searchTerms}"/>
-	<Url type="application/atom+xml" template="https://standardebooks.org/feeds/atom/all?query={searchTerms}"/>
-	<Url type="application/atom+xml;profile=opds-catalog;kind=acquisition" template="https://standardebooks.org/feeds/opds/all?query={searchTerms}"/>
+	<Url type="application/rss+xml" template="https://standardebooks.org/feeds/rss/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
+	<Url type="application/atom+xml" template="https://standardebooks.org/feeds/atom/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
+	<Url type="application/atom+xml;profile=opds-catalog;kind=acquisition" template="https://standardebooks.org/feeds/opds/all?query={searchTerms}&amp;per-page={count}&amp;page={startPage}"/>
 	<Query role="example" searchTerms="fiction" startPage="1" count="12"/>
 </OpenSearchDescription>

--- a/www/feeds/atom/search.php
+++ b/www/feeds/atom/search.php
@@ -5,9 +5,11 @@ $ebooks = [];
 
 try{
 	$query = HttpInput::Str(GET, 'query') ?? '';
+	$startPage = HttpInput::Int(GET, 'page') ?? 1;
+	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Library::Search($query);
+		$ebooks = Library::FilterEbooks($query, [], EbookSortType::Newest, $startPage, $count)['ebooks'];
 	}
 }
 catch(\Exception){

--- a/www/feeds/opds/search.php
+++ b/www/feeds/opds/search.php
@@ -5,9 +5,11 @@ $ebooks = [];
 
 try{
 	$query = HttpInput::Str(GET, 'query') ?? '';
+	$startPage = HttpInput::Int(GET, 'page') ?? 1;
+	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Library::Search($query);
+		$ebooks = Library::FilterEbooks($query, [], EbookSortType::Newest, $startPage, $count)['ebooks'];
 	}
 }
 catch(\Exception){

--- a/www/feeds/rss/search.php
+++ b/www/feeds/rss/search.php
@@ -5,9 +5,11 @@ $ebooks = [];
 
 try{
 	$query = HttpInput::Str(GET, 'query') ?? '';
+	$startPage = HttpInput::Int(GET, 'page') ?? 1;
+	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Library::Search($query);
+		$ebooks = Library::FilterEbooks($query, [], EbookSortType::Newest, $startPage, $count)['ebooks'];
 	}
 }
 catch(\Exception){


### PR DESCRIPTION
I tested URLs like this

`/feeds/opds/all?query=fiction&per-page=10&page=4`
`/feeds/rss/all?query=fiction&per-page=10&page=4`
`/feeds/atom/all?query=fiction&per-page=10&page=4`

plus the previous `query`-only searches:

`/feeds/opds/all?query=roosevelt`

and they all look good.

I'm not sure how many clients are out there to those URLs, but it will be a change that the `query`-only searches will no longer return all the search results on one page.

