### PR TITLE
Replace GetEbooksFromFilesystem with a DB implementation

### DIFF
--- a/scripts/generate-bulk-downloads
+++ b/scripts/generate-bulk-downloads
@@ -104,7 +104,7 @@ function CreateZip(string $filePath, array $ebooks, string $type, string $webRoo
 }
 
 // Iterate over all ebooks and arrange them by publication month
-foreach(Library::GetEbooksFromFilesystem($webRoot) as $ebook){
+foreach(Library::GetEbooks() as $ebook){
 	$timestamp = $ebook->EbookCreated->format('Y-m');
 	$updatedTimestamp = $ebook->EbookUpdated->getTimestamp();
 

--- a/scripts/generate-feeds
+++ b/scripts/generate-feeds
@@ -89,7 +89,7 @@ foreach($dirs as $dir){
 }
 
 // Iterate over all ebooks to build the various feeds
-foreach(Library::GetEbooksFromFilesystem($webRoot) as $ebook){
+foreach(Library::GetEbooks() as $ebook){
 	$allEbooks[] = $ebook;
 	$newestEbooks[] = $ebook;
 


### PR DESCRIPTION
Even though you said to leave bulk downloads till the very end, this small change to `scripts/generate-bulk-downloads` allows us to get rid of a fair bit of `Library` code. The script is still a beast to run, but it doesn't run any slower after getting the ebooks from the DB instead of the filesystem.

I won't work on any further changes to bulk downloads until the rest of the site is running well with the commits in this branch. 