### PR TITLE
Timestamps: Set DEFAULT and ON UPDATE values

### DIFF
--- a/config/sql/se/Artists.sql
+++ b/config/sql/se/Artists.sql
@@ -4,7 +4,7 @@ CREATE TABLE `Artists` (
   `UrlName` varchar(255) NOT NULL,
   `DeathYear` smallint unsigned NULL,
   `Created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `Updated` timestamp NOT NULL,
+  `Updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`ArtistId`),
   UNIQUE KEY `idxUnique` (`UrlName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -6,7 +6,7 @@ CREATE TABLE `Artworks` (
   `CompletedYear` smallint unsigned NULL,
   `CompletedYearIsCirca` boolean NOT NULL DEFAULT FALSE,
   `Created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `Updated` timestamp NOT NULL,
+  `Updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `Status` enum('unverified', 'approved', 'declined', 'in_use') DEFAULT 'unverified',
   `SubmitterUserId` int(10) unsigned NULL,
   `ReviewerUserId` int(10) unsigned NULL,

--- a/config/sql/se/Ebooks.sql
+++ b/config/sql/se/Ebooks.sql
@@ -2,7 +2,7 @@ CREATE TABLE `Ebooks` (
   `EbookId` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Identifier` varchar(511) NOT NULL,
   `Created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `Updated` timestamp NOT NULL,
+  `Updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `WwwFilesystemPath` varchar(511) NOT NULL,
   `RepoFilesystemPath` varchar(511) NOT NULL,
   `KindleCoverUrl` varchar(511) NULL,


### PR DESCRIPTION
Newer versions of MariaDB, such as this one included with Ubuntu 24.04:

    Server version: 10.11.8-MariaDB-0ubuntu0.24.04.1 Ubuntu 24.04

change the default behavior to not automatically set timestamp defaults and on update values:

    $ mysqld --verbose --help | grep explicit-defaults-for-timestamp
    explicit-defaults-for-timestamp                              TRUE

whereas my older machines allowed it:

    $ mysqld --verbose --help | grep explicit-defaults-for-timestamp
    explicit-defaults-for-timestamp                              FALSE

More background on the flag here: https://dev.mysql.com/doc/refman/8.4/en/timestamp-initialization.html