### PR TITLE
FilterEbooks: Require an exact match for search

### DIFF
--- a/lib/Library.php
+++ b/lib/Library.php
@@ -8,6 +8,7 @@ use function Safe\glob;
 use function Safe\ksort;
 use function Safe\preg_replace;
 use function Safe\preg_split;
+use function Safe\sprintf;
 use function Safe\usort;
 
 class Library{
@@ -45,7 +46,8 @@ class Library{
 
 		if($query !== null && $query != ''){
 			$query = trim(preg_replace('|[^a-zA-Z0-9 ]|ius', ' ', Formatter::RemoveDiacritics($query)));
-			$whereCondition .= ' AND match(e.IndexableText) against(?) ';
+			$query = sprintf('"%s"', $query);  // Require an exact match via double quotes.
+			$whereCondition .= ' AND match(e.IndexableText) against(? IN BOOLEAN MODE) ';
 			$params[] = $query;
 		}
 


### PR DESCRIPTION
This PR makes DB search match the current production site for multi-word searches like:

Jane Austen: https://standardebooks.org/ebooks?query=Jane+Austen
Mark Twain: https://standardebooks.org/ebooks?query=Mark+Twain

The current production site requires exact matching via this line in `Ebook::Contains()`:

https://github.com/standardebooks/web/blob/36a6e3b072ec7ff76486141f2a2622286786051d/lib/Ebook.php#L570

Before this PR, the `match(e.IndexableText) against(?)` SQL clause would return ebooks that had either `jane` or `austen` (either `mark` or `twain`). That would return too many irrelevant matches.

Using double quotes around the query term `IN BOOLEAN MODE` is documented here:

https://dev.mysql.com/doc/refman/8.4/en/fulltext-boolean.html
