### PR TITLE
Ebook tags: Store UrlName so it can be queried

### DIFF
--- a/config/sql/se/Tags.sql
+++ b/config/sql/se/Tags.sql
@@ -1,8 +1,10 @@
 CREATE TABLE `Tags` (
   `TagId` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Name` varchar(255) NOT NULL,
+  `UrlName` varchar(255) NULL,
   `Type` enum('artwork', 'ebook') DEFAULT 'artwork',
   PRIMARY KEY (`TagId`),
   KEY `index1` (`Name`),
-  KEY `index2` (`Type`)
+  KEY `index2` (`Type`),
+  KEY `index3` (`UrlName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/EbookTag.php
+++ b/lib/EbookTag.php
@@ -53,10 +53,11 @@ class EbookTag extends Tag{
 		$this->Validate();
 
 		Db::Query('
-			INSERT into Tags (Name, Type)
+			INSERT into Tags (Name, UrlName, Type)
 			values (?,
+				?,
 				?)
-		', [$this->Name, $this->Type]);
+		', [$this->Name, $this->UrlName, $this->Type]);
 		$this->TagId = Db::GetLastInsertedId();
 	}
 

--- a/lib/Library.php
+++ b/lib/Library.php
@@ -39,7 +39,7 @@ class Library{
 		if(sizeof($tags) > 0 && !in_array('all', $tags)){ // 0 tags means "all ebooks"
 			$joinTags = 'inner join EbookTags et using (EbookId)
 					inner join Tags t using (TagId)';
-			$whereCondition .= ' AND t.Name in ' . Db::CreateSetSql($tags) . ' ';
+			$whereCondition .= ' AND t.UrlName in ' . Db::CreateSetSql($tags) . ' ';
 			$params = $tags;
 		}
 


### PR DESCRIPTION
The search form submits the `UrlName` for tags, which have a few differences compared to their `Name`, i.e.,

```html
	<option value="childrens">Children’s</option>
...
	<option value="science-fiction">Science Fiction</option>
```

This difference is causing DB searches for those two tags to fail with no results.

The `UrlName` is the correct string to query for when searching the DB, so this PR stores it in the `Tags` table.