### PR TITLE
Add stretched words to the list of manual typogrify checks

### DIFF
--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -269,6 +269,12 @@ proceed to seal up my confession, I bring the life of that unhappy Henry Jekyll 
 							</tbody>
 						</table>
 					</li>
+					<li>
+						<p>
+							<a href="/manual/latest/single-page#8.7.7.6">Non-breaking hyphens are used when a word is stretched out for effect.</a>
+						</p>
+						<p>Although it will produce a lot of false positives, this regex can help you find stretched words: <code class="regex">(?i)([a-z])-\1</code></p>
+					</li>
 				</ul>
 				<h3>The fourth commit</h3>
 				<p>Once you’ve searched the work for the common issues above, if any manual changes were necessary, you should perform the fourth commit.</p><code class="terminal"><span><b>git</b> add -A</span> <span><b>git</b> commit -m <i>"Manual typography changes"</i></span></code>


### PR DESCRIPTION
The regex picks up a lot of words that don’t need non-breaking hyphens unfortunately, but I can’t think of anything better. Changing it to just vowels means ignoring “hm-m” or “stop-p-p”.