### PR TITLE
Remove unused core CSS rules and fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ If everything went well you should now be able to open your web browser and visi
 pip install standardebooks
 
 # The `se` command must be in your $PATH, but installing it via `pip` might not do that automatically.
-# If `which se` doesn't say anything, then either add the `pip` installation of the `se` executable to your $PATH manually, # or install it again using `pipx`; this will create a duplicate installation,
+# If `which se` doesn't say anything, then either add the `pip` installation of the `se` executable to your $PATH manually,
+# or install it again using `pipx`; this will create a duplicate installation,
 # but it will also install it in your $PATH for you:
 pipx install standardebooks
 

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1351,11 +1351,6 @@ footer > a{
 	font-size: 0;
 }
 
-footer > p{
-	display: inlie-flex;
-	align-items: center;
-}
-
 footer > p:first-child{
 	font-size: .9rem;
 }


### PR DESCRIPTION
The rules removed from `core.css` had no effect due to the invalid value of the `display` property; these changes do not affect the presentation of any content.