### PR TITLE
Add support for Mariadb to Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PHP 8+ is required.
 
 ```shell
 # Install Apache, PHP, PHP-FPM, and various other dependencies.
-sudo apt install -y git composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip apache2 apache2-utils libfcgi0ldbl task-spooler ipv6calc mariadb-server attr libapache2-mod-xsendfile libimage-exiftool-perl
+sudo apt install -y git composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip php-mysql apache2 apache2-utils libfcgi0ldbl task-spooler ipv6calc mariadb-server attr libapache2-mod-xsendfile libimage-exiftool-perl
 
 # Create the site root and logs root and clone this repo into it.
 sudo mkdir /standardebooks.org/

--- a/vms/docker/Dockerfile
+++ b/vms/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install required packages
 RUN apt update
-RUN DEBIAN_FRONTEND=noninteractive apt install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip apache2 apache2-utils libfcgi0ldbl task-spooler libaprutil1-dbd-mysql attr libapache2-mod-xsendfile sudo imagemagick openjdk-8-jre python3 pip calibre
+RUN DEBIAN_FRONTEND=noninteractive apt install -y composer php-fpm php-cli php-gd php-xml php-apcu php-mbstring php-intl php-curl php-zip php-mysql apache2 apache2-utils libfcgi0ldbl task-spooler ipv6calc mariadb-server attr libapache2-mod-xsendfile libimage-exiftool-perl sudo imagemagick openjdk-8-jre python3 pip calibre
 
 # Install Python package for standardebooks
 RUN pip install standardebooks
@@ -15,9 +15,10 @@ RUN sudo usermod -g committers se
 # Create necessary directories
 RUN mkdir -p /standardebooks.org/web
 RUN mkdir /var/log/local
+RUN mkdir /run/php
 
 # Enable Apache modules
-RUN a2enmod headers expires ssl rewrite proxy proxy_fcgi authn_dbd authn_socache
+RUN a2enmod headers expires ssl rewrite proxy proxy_fcgi xsendfile
 
 # Disable opcode caching to enable dynamic PHP reloading
 RUN echo "opcache.enable=0" | tee --append /etc/php/*/fpm/php.ini

--- a/vms/docker/start-server.sh
+++ b/vms/docker/start-server.sh
@@ -15,12 +15,18 @@ ln -s /standardebooks.org/web/config/php/fpm/standardebooks.test.ini /etc/php/*/
 ln -s /standardebooks.org/web/config/php/fpm/standardebooks.test.ini /etc/php/*/fpm/conf.d/
 ln -s /standardebooks.org/web/config/php/fpm/standardebooks.test.conf /etc/php/*/fpm/pool.d/
 
+# Create and populate the SE database.
+service mariadb start
+mariadb < /standardebooks.org/web/config/sql/se.sql
+mariadb < /standardebooks.org/web/config/sql/users.sql
+mariadb se < /standardebooks.org/web/config/sql/se/*.sql
+
 # Enable web server configuration
 a2ensite standardebooks.test
 
 # Restart services to load new configuration
 service apache2 restart
-service php7.4-fpm restart
+service php8.1-fpm restart
 
 # Keep the server available by holding open the container
 tail -f /dev/null


### PR DESCRIPTION
Nothing particularly complex here. A PDO error confused me for a bit until I worked out that `php-mysql` was missing, and also from the installation instructions in the README. If I’m mistaken there please let me know.