### PR TITLE
Uncomment call to chapter navigation footer script

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -354,7 +354,7 @@ do
 		find "${workDir}"/src/epub \( -type d -name .git -prune \) -o -type f -name "*.xhtml" -print0 | xargs -0 sed --in-place --regexp-extended "s|<body([^>]*)>|<body\1><header><nav><ul><li><a href=\"/\">Standard Ebooks</a></li><li><a href=\"${bookUrl}\">Back to ebook</a></li><li><a href=\"${bookUrl}/text\">Table of contents</a></li></ul></nav></header>|"
 
 		# Add a chapter navigation footer to each page.
-		#"${scriptsDir}"/inject-chapter-navigation-footer "${workDir}" "${bookUrl}"
+		"${scriptsDir}"/inject-chapter-navigation-footer "${workDir}" "${bookUrl}"
 
 		# Adjust sponsored links in the colophon.
 		sed --in-place 's|<p><a href="http|<p><a rel="nofollow" href="http|g' "${workDir}"/src/epub/text/colophon.xhtml


### PR DESCRIPTION
The navigation footer is missing from all ebooks released after Thucydides, while it's present in older ones. The line calling the script was commented out recently in  https://github.com/standardebooks/web/commit/d6a2bdcbc864c4513085c9abd3e40f4940df1c53#diff-973dffe2ed8a36c6163eb89a9dac6ad50951e96d3374a667eaed7b925165b27aL357

It's more likely than not that there's a problem with the script I'm not seeing, but even so it doesn't seem like commenting it out is a change that belongs with the rest of the changes in the commit.