### PR TITLE
Complete placeholder form and add POST handler

### DIFF
--- a/config/sql/se/EbookPlaceholders.sql
+++ b/config/sql/se/EbookPlaceholders.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `EbookPlaceholders` (
   `EbookId` int(10) unsigned NOT NULL,
   `YearPublished` smallint unsigned NULL,
-  `Status` enum('wanted', 'in_progress') NOT NULL DEFAULT 'wanted',
+  `Status` enum('wanted', 'in_progress') NULL,
   `Difficulty` enum('beginner', 'intermediate', 'advanced') NULL,
   `TranscriptionUrl` varchar(511) NULL,
   `IsWanted` boolean NOT NULL DEFAULT FALSE,

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -29,7 +29,8 @@ const MANUAL_PATH =			WEB_ROOT . '/manual';
 const EBOOKS_DIST_PATH =		WEB_ROOT . '/ebooks/';
 const COVER_ART_UPLOAD_PATH =		'/images/cover-uploads/';
 
-const EBOOKS_IDENTIFIER_PREFIX =	'url:https://standardebooks.org/ebooks/';
+const EBOOKS_IDENTIFIER_ROOT =		'url:https://standardebooks.org';
+const EBOOKS_IDENTIFIER_PREFIX =	EBOOKS_IDENTIFIER_ROOT . '/ebooks/';
 
 const DATABASE_DEFAULT_DATABASE = 	'se';
 const DATABASE_DEFAULT_HOST = 		'localhost';

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -981,7 +981,22 @@ class Ebook{
 	}
 
 	/**
-	 * Populate the `Identifier` property based on the `Title`, `Authors`, `Translators`, and `Illustrators`. Used when creating ebook placeholders.
+	 * Joins the `Name` properites of `Contributor` objects as a URL slug, e.g.,
+	 *
+	 * 	```
+	 * 	([0] => Contributor Object ([Name] => William Wordsworth), ([1] => Contributor Object ([Name] => Samuel Coleridge)))
+	 * 	```
+	 *
+	 * returns `william-wordsworth_samuel-taylor-coleridge`.
+	 *
+	 * @param array<Contributor> $contributors
+	 */
+	protected static function GetContributorsUrlSlug(array $contributors): string{
+		return implode('_', array_map('Formatter::MakeUrlSafe', array_column($contributors, 'Name')));
+	}
+
+	/**
+	 * Populates the `Identifier` property based on the `Title`, `Authors`, `Translators`, and `Illustrators`. Used when creating ebook placeholders.
 	 *
 	 * @throws Exceptions\InvalidEbookIdentifierException
 	 */
@@ -994,17 +1009,17 @@ class Ebook{
 			throw new Exceptions\InvalidEbookIdentifierException('Title required');
 		}
 
-		$authorString = implode('_', array_map('Formatter::MakeUrlSafe', array_column($this->Authors, 'Name')));
+		$authorString = Ebook::GetContributorsUrlSlug($this->Authors);
 		$titleString = Formatter::MakeUrlSafe($this->Title);
 		$translatorString = '';
 		$illustratorString = '';
 
 		if(isset($this->Translators) || !empty($this->Translators)){
-			$translatorString = implode('_', array_map('Formatter::MakeUrlSafe', array_column($this->Translators, 'Name')));
+			$translatorString = Ebook::GetContributorsUrlSlug($this->Translators);
 		}
 
 		if(isset($this->Illustrators) || !empty($this->Illustrators)){
-			$illustratorString = implode('_', array_map('Formatter::MakeUrlSafe', array_column($this->Illustrators, 'Name')));
+			$illustratorString = Ebook::GetContributorsUrlSlug($this->Illustrators);
 		}
 
 		$this->Identifier = EBOOKS_IDENTIFIER_PREFIX . $authorString . '/' . $titleString;

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -1024,11 +1024,11 @@ class Ebook{
 
 		$this->Identifier = EBOOKS_IDENTIFIER_PREFIX . $authorString . '/' . $titleString;
 
-		if(!empty($translatorString)){
+		if($translatorString != ''){
 			$this->Identifier .= '/' . $translatorString;
 		}
 
-		if(!empty($illustratorString)){
+		if($illustratorString != ''){
 			$this->Identifier .= '/' . $illustratorString;
 		}
 	}

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -1001,7 +1001,7 @@ class Ebook{
 	 * @throws Exceptions\InvalidEbookIdentifierException
 	 */
 	public function FillIdentifierFromTitleAndContributors(): void{
-		if(!isset($this->Authors) || empty($this->Authors)){
+		if(!isset($this->Authors) || sizeof($this->Authors) == 0){
 			throw new Exceptions\InvalidEbookIdentifierException('Authors required');
 		}
 
@@ -1014,11 +1014,11 @@ class Ebook{
 		$translatorString = '';
 		$illustratorString = '';
 
-		if(isset($this->Translators) || !empty($this->Translators)){
+		if(isset($this->Translators) && sizeof($this->Translators) > 0){
 			$translatorString = Ebook::GetContributorsUrlSlug($this->Translators);
 		}
 
-		if(isset($this->Illustrators) || !empty($this->Illustrators)){
+		if(isset($this->Illustrators) && sizeof($this->Illustrators) > 0){
 			$illustratorString = Ebook::GetContributorsUrlSlug($this->Illustrators);
 		}
 

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -608,12 +608,11 @@ class Ebook{
 
 	protected function GetEbookPlaceholder(): ?EbookPlaceholder{
 		if(!isset($this->_EbookPlaceholder)){
-			$result = Db::Query('
-					SELECT *
-					from EbookPlaceholders
-					where EbookId = ?
-				', [$this->EbookId], EbookPlaceholder::class);
-			$this->_EbookPlaceholder = $result[0] ?? null;
+			$this->_EbookPlaceholder = Db::Query('
+							SELECT *
+							from EbookPlaceholders
+							where EbookId = ?
+						', [$this->EbookId], EbookPlaceholder::class)[0] ?? null;
 		}
 
 		return $this->_EbookPlaceholder;

--- a/lib/EbookPlaceholder.php
+++ b/lib/EbookPlaceholder.php
@@ -1,0 +1,70 @@
+<?
+
+class EbookPlaceholder{
+	use Traits\PropertyFromHttp;
+
+	public int $EbookId;
+	public ?int $YearPublished = null;
+	public Enums\EbookPlaceholderStatus $Status;
+	public ?Enums\EbookPlaceholderDifficulty $Difficulty = null;
+	public ?string $TranscriptionUrl = null;
+	public bool $IsWanted = false;
+	public bool $IsPatron = false;
+	public ?string $Notes = null;
+
+	public function FillFromHttpPost(): void{
+		$this->PropertyFromHttp('YearPublished');
+		$this->PropertyFromHttp('Status');
+		$this->PropertyFromHttp('Difficulty');
+		$this->PropertyFromHttp('TranscriptionUrl');
+		$this->PropertyFromHttp('IsWanted');
+		$this->PropertyFromHttp('IsPatron');
+		$this->PropertyFromHttp('Notes');
+	}
+
+	/**
+	 * @throws Exceptions\ValidationException
+	 */
+	public function Validate(): void{
+		$thisYear = intval(NOW->format('Y'));
+		$error = new Exceptions\ValidationException();
+
+		if(isset($this->YearPublished) && ($this->YearPublished <= 0 || $this->YearPublished > $thisYear)){
+			$error->Add(new Exceptions\InvalidEbookPlaceholderYearPublishedException());
+		}
+
+		$this->TranscriptionUrl = trim($this->TranscriptionUrl ?? '');
+		if($this->TranscriptionUrl == ''){
+			$this->TranscriptionUrl = null;
+		}
+
+		$this->Notes = trim($this->Notes ?? '');
+		if($this->Notes == ''){
+			$this->Notes = null;
+		}
+
+		if($error->HasExceptions){
+			throw $error;
+		}
+	}
+
+	/**
+	 * @throws Exceptions\ValidationException
+	 */
+	public function Create(): void{
+		$this->Validate();
+		Db::Query('
+			INSERT into EbookPlaceholders (EbookId, YearPublished, Status, Difficulty, TranscriptionUrl,
+				IsWanted, IsPatron, Notes)
+			values (?,
+				?,
+				?,
+				?,
+				?,
+				?,
+				?,
+				?)
+		', [$this->EbookId, $this->YearPublished, $this->Status, $this->Difficulty, $this->TranscriptionUrl,
+			$this->IsWanted, $this->IsPatron, $this->Notes]);
+	}
+}

--- a/lib/EbookPlaceholder.php
+++ b/lib/EbookPlaceholder.php
@@ -5,21 +5,25 @@ class EbookPlaceholder{
 
 	public int $EbookId;
 	public ?int $YearPublished = null;
-	public Enums\EbookPlaceholderStatus $Status;
+	public bool $IsWanted = false;
+	public ?Enums\EbookPlaceholderStatus $Status = null;
 	public ?Enums\EbookPlaceholderDifficulty $Difficulty = null;
 	public ?string $TranscriptionUrl = null;
-	public bool $IsWanted = false;
 	public bool $IsPatron = false;
 	public ?string $Notes = null;
 
 	public function FillFromHttpPost(): void{
 		$this->PropertyFromHttp('YearPublished');
-		$this->PropertyFromHttp('Status');
-		$this->PropertyFromHttp('Difficulty');
-		$this->PropertyFromHttp('TranscriptionUrl');
 		$this->PropertyFromHttp('IsWanted');
-		$this->PropertyFromHttp('IsPatron');
-		$this->PropertyFromHttp('Notes');
+
+		// These properties apply only to books on the SE wanted list.
+		if($this->IsWanted){
+			$this->PropertyFromHttp('Status');
+			$this->PropertyFromHttp('Difficulty');
+			$this->PropertyFromHttp('TranscriptionUrl');
+			$this->PropertyFromHttp('IsPatron');
+			$this->PropertyFromHttp('Notes');
+		}
 	}
 
 	/**

--- a/lib/Enums/EbookPlaceholderDifficulty.php
+++ b/lib/Enums/EbookPlaceholderDifficulty.php
@@ -1,0 +1,8 @@
+<?
+namespace Enums;
+
+enum EbookPlaceholderDifficulty: string{
+	case Beginner = 'beginner';
+	case Intermediate = 'intermediate';
+	case Advanced = 'advanced';
+}

--- a/lib/Enums/EbookPlaceholderStatus.php
+++ b/lib/Enums/EbookPlaceholderStatus.php
@@ -1,0 +1,7 @@
+<?
+namespace Enums;
+
+enum EbookPlaceholderStatus: string{
+	case Wanted = 'wanted';
+	case InProgress = 'in_progress';
+}

--- a/lib/Exceptions/DuplicateEbookException.php
+++ b/lib/Exceptions/DuplicateEbookException.php
@@ -1,0 +1,10 @@
+<?
+namespace Exceptions;
+
+class DuplicateEbookException extends AppException{
+	public function __construct(string $identifier){
+		$this->message = 'Ebook already exists with identifier: ' . $identifier;
+
+		parent::__construct($this->message);
+	}
+}

--- a/lib/Exceptions/EbookMissingPlaceholderException.php
+++ b/lib/Exceptions/EbookMissingPlaceholderException.php
@@ -1,0 +1,7 @@
+<?
+namespace Exceptions;
+
+class EbookMissingPlaceholderException extends AppException{
+	/** @var string $message */
+	protected $message = 'Ebook is a placeholder, but has no placeholder object.';
+}

--- a/lib/Exceptions/EbookUnexpectedPlaceholderException.php
+++ b/lib/Exceptions/EbookUnexpectedPlaceholderException.php
@@ -1,0 +1,7 @@
+<?
+namespace Exceptions;
+
+class EbookUnexpectedPlaceholderException extends AppException{
+	/** @var string $message */
+	protected $message = 'Ebook is not a placeholder, but has a placeholder object.';
+}

--- a/lib/Exceptions/InvalidEbookIdentifierException.php
+++ b/lib/Exceptions/InvalidEbookIdentifierException.php
@@ -1,0 +1,5 @@
+<?
+namespace Exceptions;
+
+class InvalidEbookIdentifierException extends AppException{
+}

--- a/lib/Exceptions/InvalidEbookPlaceholderYearPublishedException.php
+++ b/lib/Exceptions/InvalidEbookPlaceholderYearPublishedException.php
@@ -1,0 +1,7 @@
+<?
+namespace Exceptions;
+
+class InvalidEbookPlaceholderYearPublishedException extends AppException{
+	/** @var string $message */
+	protected $message = 'Invalid ebook placeholder year published.';
+}

--- a/templates/EbookPlaceholderForm.php
+++ b/templates/EbookPlaceholderForm.php
@@ -174,47 +174,49 @@ $ebook = $ebook ?? new Ebook();
 			<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->IsWanted){ ?>checked="checked"<? } ?>
 		/>
 	</label>
-	<label>
-		<span>Did a Patron request this book?</span>
-		<input
-			type="checkbox"
-			name="ebook-placeholder-is-patron"
-			<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->IsPatron){ ?>checked="checked"<? } ?>
-		/>
-	</label>
-	<label>
-		<span>Difficulty</span>
-		<span>
-			<select name="ebook-placeholder-difficulty">
-				<option value=""></option>
-				<option value="<?= \Enums\EbookPlaceholderDifficulty::Beginner->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Beginner){ ?> selected="selected"<? } ?>>Beginner</option>
-				<option value="<?= \Enums\EbookPlaceholderDifficulty::Intermediate->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Intermediate){ ?> selected="selected"<? } ?>>Intermediate</option>
-				<option value="<?= \Enums\EbookPlaceholderDifficulty::Advanced->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Advanced){ ?> selected="selected"<? } ?>>Advanced</option>
-			</select>
-		</span>
-	</label>
-	<label>
-		<span>Wanted list status</span>
-		<span>
-			<select name="ebook-placeholder-status">
-				<option value="<?= \Enums\EbookPlaceholderStatus::Wanted->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::Wanted){ ?> selected="selected"<? } ?>>Wanted</option>
-				<option value="<?= \Enums\EbookPlaceholderStatus::InProgress->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::InProgress){ ?> selected="selected"<? } ?>>In progress</option>
-			</select>
-		</span>
-	</label>
-	<label>
-		<span>Transcription URL</span>
-		<input
-			type="text"
-			name="ebook-placeholder-transcription-url"
-			value="<? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->TranscriptionUrl) ?><? } ?>"
-		/>
-	</label>
-	<label>
-		<span>Wanted list notes</span>
-		<span>Markdown accepted</span>
-		<textarea maxlength="1024" name="ebook-placeholder-notes"><? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->Notes) ?><? } ?></textarea>
-	</label>
+	<fieldset>
+		<label>
+			<span>Did a Patron request this book?</span>
+			<input
+				type="checkbox"
+				name="ebook-placeholder-is-patron"
+				<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->IsPatron){ ?>checked="checked"<? } ?>
+			/>
+		</label>
+		<label>
+			<span>Difficulty</span>
+			<span>
+				<select name="ebook-placeholder-difficulty">
+					<option value=""></option>
+					<option value="<?= Enums\EbookPlaceholderDifficulty::Beginner->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Beginner){ ?> selected="selected"<? } ?>>Beginner</option>
+					<option value="<?= Enums\EbookPlaceholderDifficulty::Intermediate->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Intermediate){ ?> selected="selected"<? } ?>>Intermediate</option>
+					<option value="<?= Enums\EbookPlaceholderDifficulty::Advanced->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Advanced){ ?> selected="selected"<? } ?>>Advanced</option>
+				</select>
+			</span>
+		</label>
+		<label>
+			<span>Wanted list status</span>
+			<span>
+				<select name="ebook-placeholder-status">
+					<option value="<?= Enums\EbookPlaceholderStatus::Wanted->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::Wanted){ ?> selected="selected"<? } ?>>Wanted</option>
+					<option value="<?= Enums\EbookPlaceholderStatus::InProgress->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::InProgress){ ?> selected="selected"<? } ?>>In progress</option>
+				</select>
+			</span>
+		</label>
+		<label>
+			<span>Transcription URL</span>
+			<input
+				type="text"
+				name="ebook-placeholder-transcription-url"
+				value="<? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->TranscriptionUrl) ?><? } ?>"
+			/>
+		</label>
+		<label>
+			<span>Wanted list notes</span>
+			<span>Markdown accepted</span>
+			<textarea maxlength="1024" name="ebook-placeholder-notes"><? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->Notes) ?><? } ?></textarea>
+		</label>
+	</fieldset>
 </fieldset>
 <div class="footer">
 	<button>Submit</button>

--- a/templates/EbookPlaceholderForm.php
+++ b/templates/EbookPlaceholderForm.php
@@ -16,30 +16,65 @@ $ebook = $ebook ?? new Ebook();
 		</datalist>
 		<input
 			type="text"
-			name="author-name"
+			name="author-name-1"
 			list="author-names"
 			required="required"
-		/>
-	</label>
-	<label class="user">
-		<span>Translator</span>
-		<datalist id="translator-names">
-			<? foreach(Contributor::GetAllTranslatorNames() as $translator){ ?>
-				<option value="<?= Formatter::EscapeHtml($translator->Name) ?>"><?= Formatter::EscapeHtml($translator->Name) ?></option>
-			<? } ?>
-		</datalist>
-		<input
-			type="text"
-			name="translator-name"
-			list="translator-names"
+			value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 0){ ?><?= Formatter::EscapeHtml($ebook->Authors[0]->Name) ?><? } ?>"
 		/>
 	</label>
 </fieldset>
+<details>
+	<summary>Additional contributors</summary>
+	<fieldset>
+		<label class="user">
+			<span>Second author</span>
+			<input
+				type="text"
+				name="author-name-2"
+				list="author-names"
+				value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 1){ ?><?= Formatter::EscapeHtml($ebook->Authors[1]->Name) ?><? } ?>"
+			/>
+		</label>
+		<label class="user">
+			<span>Third author</span>
+			<input
+				type="text"
+				name="author-name-3"
+				list="author-names"
+				value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 2){ ?><?= Formatter::EscapeHtml($ebook->Authors[2]->Name) ?><? } ?>"
+			/>
+		</label>
+		<label class="user">
+			<span>Translator</span>
+			<datalist id="translator-names">
+				<? foreach(Contributor::GetAllTranslatorNames() as $translator){ ?>
+					<option value="<?= Formatter::EscapeHtml($translator->Name) ?>"><?= Formatter::EscapeHtml($translator->Name) ?></option>
+				<? } ?>
+			</datalist>
+			<input
+				type="text"
+				name="translator-name-1"
+				list="translator-names"
+				value="<? if(isset($ebook->Translators) && count($ebook->Translators) > 0){ ?><?= Formatter::EscapeHtml($ebook->Translators[0]->Name) ?><? } ?>"
+			/>
+		</label>
+		<label class="user">
+			<span>Second translator</span>
+			<input
+				type="text"
+				name="translator-name-2"
+				list="translator-names"
+				value="<? if(isset($ebook->Translators) && count($ebook->Translators) > 1){ ?><?= Formatter::EscapeHtml($ebook->Translators[1]->Name) ?><? } ?>"
+			/>
+		</label>
+	</fieldset>
+</details>
 <fieldset>
 	<legend>Ebook metadata</legend>
 	<label>
 		<span>Title</span>
-		<input type="text" name="ebook-title" required="required"/>
+		<input type="text" name="ebook-title" required="required"
+		       value="<? if(isset($ebook->Title)){ ?><?= Formatter::EscapeHtml($ebook->Title) ?><? } ?>"/>
 	</label>
 	<fieldset>
 		<label class="year">
@@ -48,7 +83,9 @@ $ebook = $ebook ?? new Ebook();
 				type="text"
 				name="ebook-placeholder-year-published"
 				inputmode="numeric"
-				pattern="[0-9]{1,4}"/>
+				pattern="[0-9]{1,4}"
+				value="<? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml((string)$ebook->EbookPlaceholder->YearPublished) ?><? } ?>"
+			/>
 		</label>
 	</fieldset>
 	<label>
@@ -60,42 +97,109 @@ $ebook = $ebook ?? new Ebook();
 		</datalist>
 		<input
 			type="text"
-			name="collection-name"
-			list="collection-names"/>
+			name="collection-name-1"
+			list="collection-names"
+			value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[0]->Collection->Name) ?><? } ?>"
+		/>
 	</label>
 	<fieldset>
 		<label>
 			<span>Number in collection</span>
 			<input
 				type="text"
-				name="collection-membership-sequence-number"
+				name="sequence-number-collection-name-1"
 				inputmode="numeric"
-				pattern="[0-9]{1,3}"/>
+				pattern="[0-9]{1,3}"
+				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+			/>
 		</label>
 	</fieldset>
 </fieldset>
+<details>
+	<summary>Additional collections</summary>
+	<fieldset>
+		<label>
+			<span>Second Collection</span>
+			<datalist id="collection-names">
+				<? foreach(Collection::GetAll() as $collection){ ?>
+					<option value="<?= Formatter::EscapeHtml($collection->Name) ?>"><?= Formatter::EscapeHtml($collection->Name) ?></option>
+				<? } ?>
+			</datalist>
+			<input
+				type="text"
+				name="collection-name-2"
+				list="collection-names"
+				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[0]->Collection->Name) ?><? } ?>"
+			/>
+		</label>
+		<fieldset>
+			<label>
+				<span>Number in collection</span>
+				<input
+					type="text"
+					name="sequence-number-collection-name-2"
+					inputmode="numeric"
+					pattern="[0-9]{1,3}"
+					value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+				/>
+			</label>
+		</fieldset>
+	</fieldset>
+	<fieldset>
+		<label>
+			<span>Third Collection</span>
+			<datalist id="collection-names">
+				<? foreach(Collection::GetAll() as $collection){ ?>
+					<option value="<?= Formatter::EscapeHtml($collection->Name) ?>"><?= Formatter::EscapeHtml($collection->Name) ?></option>
+				<? } ?>
+			</datalist>
+			<input
+				type="text"
+				name="collection-name-3"
+				list="collection-names"
+				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[0]->Collection->Name) ?><? } ?>"
+			/>
+		</label>
+		<fieldset>
+			<label>
+				<span>Number in collection</span>
+				<input
+					type="text"
+					name="sequence-number-collection-name-3"
+					inputmode="numeric"
+					pattern="[0-9]{1,3}"
+					value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+				/>
+			</label>
+		</fieldset>
+	</fieldset>
+</details>
 <fieldset>
 	<legend>Corpus details</legend>
 	<label>
 		<span>On the SE wanted list?</span>
 		<input
 			type="checkbox"
-			name="ebook-placeholder-is-wanted"/>
+			name="ebook-placeholder-is-wanted"
+			<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->IsWanted){ ?>checked="checked"<? } ?>
+		/>
 	</label>
 	<label>
 		<span>Did a Patron request this book?</span>
 		<input
 			type="checkbox"
-			name="ebook-placeholder-is-patron"/>
+			name="ebook-placeholder-is-patron"
+			<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->IsPatron){ ?>checked="checked"<? } ?>
+		/>
 	</label>
 	<label>
 		<span>Difficulty</span>
 		<span>
 			<select name="ebook-placeholder-difficulty">
 				<option value=""></option>
-				<option value="beginner">Beginner</option>
-				<option value="intermediate">Intermediate</option>
-				<option value="advanced">Advanced</option>
+				<option value="<?= \Enums\EbookPlaceholderDifficulty::Beginner->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Beginner){ ?> selected="selected"<? } ?>>Beginner</option>
+				<option value="<?= \Enums\EbookPlaceholderDifficulty::Intermediate->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Intermediate){ ?> selected="selected"<? } ?>>Intermediate</option>
+				<option value="<?= \Enums\EbookPlaceholderDifficulty::Advanced->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Difficulty == Enums\EbookPlaceholderDifficulty::Advanced){ ?> selected="selected"<? } ?>>Advanced</option>
 			</select>
 		</span>
 	</label>
@@ -103,8 +207,8 @@ $ebook = $ebook ?? new Ebook();
 		<span>Wanted list status</span>
 		<span>
 			<select name="ebook-placeholder-status">
-				<option value="wanted">Wanted</option>
-				<option value="in-progress">In progress</option>
+				<option value="<?= \Enums\EbookPlaceholderStatus::Wanted->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::Wanted){ ?> selected="selected"<? } ?>>Wanted</option>
+				<option value="<?= \Enums\EbookPlaceholderStatus::InProgress->value ?>"<? if(isset($ebook->EbookPlaceholder) && $ebook->EbookPlaceholder->Status == Enums\EbookPlaceholderStatus::InProgress){ ?> selected="selected"<? } ?>>In progress</option>
 			</select>
 		</span>
 	</label>
@@ -112,12 +216,14 @@ $ebook = $ebook ?? new Ebook();
 		<span>Transcription URL</span>
 		<input
 			type="text"
-			name="ebook-placeholder-transcription-url"/>
+			name="ebook-placeholder-transcription-url"
+			value="<? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->TranscriptionUrl) ?><? } ?>"
+		/>
 	</label>
 	<label>
 		<span>Wanted list notes</span>
 		<span>Markdown accepted</span>
-		<textarea maxlength="1024" name="ebook-placeholder-notes"></textarea>
+		<textarea maxlength="1024" name="ebook-placeholder-notes"><? if(isset($ebook->EbookPlaceholder)){ ?><?= Formatter::EscapeHtml($ebook->EbookPlaceholder->Notes) ?><? } ?></textarea>
 	</label>
 </fieldset>
 <div class="footer">

--- a/templates/EbookPlaceholderForm.php
+++ b/templates/EbookPlaceholderForm.php
@@ -110,7 +110,7 @@ $ebook = $ebook ?? new Ebook();
 				name="sequence-number-collection-name-1"
 				inputmode="numeric"
 				pattern="[0-9]{1,3}"
-				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+				value="<? if(isset($ebook->CollectionMemberships) && sizeof($ebook->CollectionMemberships) > 0){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
 			/>
 		</label>
 	</fieldset>
@@ -120,16 +120,11 @@ $ebook = $ebook ?? new Ebook();
 	<fieldset>
 		<label>
 			<span>Second Collection</span>
-			<datalist id="collection-names">
-				<? foreach(Collection::GetAll() as $collection){ ?>
-					<option value="<?= Formatter::EscapeHtml($collection->Name) ?>"><?= Formatter::EscapeHtml($collection->Name) ?></option>
-				<? } ?>
-			</datalist>
 			<input
 				type="text"
 				name="collection-name-2"
 				list="collection-names"
-				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[0]->Collection->Name) ?><? } ?>"
+				value="<? if(isset($ebook->CollectionMemberships) && sizeof($ebook->CollectionMemberships) > 1){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[1]->Collection->Name) ?><? } ?>"
 			/>
 		</label>
 		<fieldset>
@@ -140,7 +135,7 @@ $ebook = $ebook ?? new Ebook();
 					name="sequence-number-collection-name-2"
 					inputmode="numeric"
 					pattern="[0-9]{1,3}"
-					value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+					value="<? if(isset($ebook->CollectionMemberships) && sizeof($ebook->CollectionMemberships) > 1){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[1]->SequenceNumber) ?><? } ?>"
 				/>
 			</label>
 		</fieldset>
@@ -148,16 +143,11 @@ $ebook = $ebook ?? new Ebook();
 	<fieldset>
 		<label>
 			<span>Third Collection</span>
-			<datalist id="collection-names">
-				<? foreach(Collection::GetAll() as $collection){ ?>
-					<option value="<?= Formatter::EscapeHtml($collection->Name) ?>"><?= Formatter::EscapeHtml($collection->Name) ?></option>
-				<? } ?>
-			</datalist>
 			<input
 				type="text"
 				name="collection-name-3"
 				list="collection-names"
-				value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[0]->Collection->Name) ?><? } ?>"
+				value="<? if(isset($ebook->CollectionMemberships) && sizeof($ebook->CollectionMemberships) > 2){ ?><?= Formatter::EscapeHtml($ebook->CollectionMemberships[2]->Collection->Name) ?><? } ?>"
 			/>
 		</label>
 		<fieldset>
@@ -168,7 +158,7 @@ $ebook = $ebook ?? new Ebook();
 					name="sequence-number-collection-name-3"
 					inputmode="numeric"
 					pattern="[0-9]{1,3}"
-					value="<? if(isset($ebook->CollectionMemberships)){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[0]->SequenceNumber) ?><? } ?>"
+					value="<? if(isset($ebook->CollectionMemberships) && sizeof($ebook->CollectionMemberships) > 2){ ?><?= Formatter::EscapeHtml((string)$ebook->CollectionMemberships[2]->SequenceNumber) ?><? } ?>"
 				/>
 			</label>
 		</fieldset>

--- a/templates/EbookPlaceholderForm.php
+++ b/templates/EbookPlaceholderForm.php
@@ -19,7 +19,7 @@ $ebook = $ebook ?? new Ebook();
 			name="author-name-1"
 			list="author-names"
 			required="required"
-			value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 0){ ?><?= Formatter::EscapeHtml($ebook->Authors[0]->Name) ?><? } ?>"
+			value="<? if(isset($ebook->Authors) && sizeof($ebook->Authors) > 0){ ?><?= Formatter::EscapeHtml($ebook->Authors[0]->Name) ?><? } ?>"
 		/>
 	</label>
 </fieldset>
@@ -32,7 +32,7 @@ $ebook = $ebook ?? new Ebook();
 				type="text"
 				name="author-name-2"
 				list="author-names"
-				value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 1){ ?><?= Formatter::EscapeHtml($ebook->Authors[1]->Name) ?><? } ?>"
+				value="<? if(isset($ebook->Authors) && sizeof($ebook->Authors) > 1){ ?><?= Formatter::EscapeHtml($ebook->Authors[1]->Name) ?><? } ?>"
 			/>
 		</label>
 		<label class="user">
@@ -41,7 +41,7 @@ $ebook = $ebook ?? new Ebook();
 				type="text"
 				name="author-name-3"
 				list="author-names"
-				value="<? if(isset($ebook->Authors) && count($ebook->Authors) > 2){ ?><?= Formatter::EscapeHtml($ebook->Authors[2]->Name) ?><? } ?>"
+				value="<? if(isset($ebook->Authors) && sizeof($ebook->Authors) > 2){ ?><?= Formatter::EscapeHtml($ebook->Authors[2]->Name) ?><? } ?>"
 			/>
 		</label>
 		<label class="user">
@@ -55,7 +55,7 @@ $ebook = $ebook ?? new Ebook();
 				type="text"
 				name="translator-name-1"
 				list="translator-names"
-				value="<? if(isset($ebook->Translators) && count($ebook->Translators) > 0){ ?><?= Formatter::EscapeHtml($ebook->Translators[0]->Name) ?><? } ?>"
+				value="<? if(isset($ebook->Translators) && sizeof($ebook->Translators) > 0){ ?><?= Formatter::EscapeHtml($ebook->Translators[0]->Name) ?><? } ?>"
 			/>
 		</label>
 		<label class="user">
@@ -64,7 +64,7 @@ $ebook = $ebook ?? new Ebook();
 				type="text"
 				name="translator-name-2"
 				list="translator-names"
-				value="<? if(isset($ebook->Translators) && count($ebook->Translators) > 1){ ?><?= Formatter::EscapeHtml($ebook->Translators[1]->Name) ?><? } ?>"
+				value="<? if(isset($ebook->Translators) && sizeof($ebook->Translators) > 1){ ?><?= Formatter::EscapeHtml($ebook->Translators[1]->Name) ?><? } ?>"
 			/>
 		</label>
 	</fieldset>

--- a/www/css/ebook-placeholder.css
+++ b/www/css/ebook-placeholder.css
@@ -32,7 +32,6 @@ form.create-update-ebook-placeholder fieldset fieldset:has(input[name="ebook-pla
 	gap: 2rem;
 }
 
-form.create-update-ebook-placeholder fieldset label:has(input[type="url"]),
 form.create-update-ebook-placeholder fieldset label:has(input[type="checkbox"]){
 	grid-column: 1 / span 2;
 }
@@ -71,4 +70,14 @@ form.create-update-ebook-placeholder label{
 form div.footer{
 	margin-top: 1rem;
 	text-align: right;
+}
+
+/* Hide the next fieldset unless the ebook-placeholder-is-wanted checkbox is checked. */
+form.create-update-ebook-placeholder fieldset:has(input[name="ebook-placeholder-is-wanted"]) fieldset{
+	display: none;
+	grid-column: 1 / span 2;
+}
+
+form.create-update-ebook-placeholder fieldset:has(input[name="ebook-placeholder-is-wanted"]:checked) fieldset{
+	display: grid;
 }

--- a/www/css/ebook-placeholder.css
+++ b/www/css/ebook-placeholder.css
@@ -1,28 +1,31 @@
-form.create-update-ebook-placeholder > fieldset{
+form.create-update-ebook-placeholder fieldset{
 	display: grid;
 	gap: 2rem;
 }
 
-form.create-update-ebook-placeholder > fieldset + fieldset{
+form.create-update-ebook-placeholder details + fieldset,
+form.create-update-ebook-placeholder fieldset + fieldset{
 	margin-top: 2rem;
 }
 
-/* Artist details */
-form.create-update-ebook-placeholder > fieldset:nth-of-type(1){
+form.create-update-ebook-placeholder > fieldset:nth-of-type(1),
+form.create-update-ebook-placeholder details:nth-of-type(1) fieldset{
 	grid-template-columns: 1fr 1fr;
 }
 
-/* Artwork details */
-form.create-update-ebook-placeholder > fieldset:nth-of-type(2){
+form.create-update-ebook-placeholder > fieldset:nth-of-type(2),
+form.create-update-ebook-placeholder details:nth-of-type(2) fieldset{
 	grid-template-columns: 1fr 200px;
 }
 
-form.create-update-ebook-placeholder > fieldset label:has(input[name="ebook-placeholder-transcription-url"]),
-form.create-update-ebook-placeholder > fieldset label:has(textarea[name="ebook-placeholder-notes"]){
+form.create-update-ebook-placeholder fieldset label:has(input[name="ebook-placeholder-transcription-url"]),
+form.create-update-ebook-placeholder fieldset label:has(textarea[name="ebook-placeholder-notes"]){
 	grid-column: 1 / span 2;
 }
 
-form.create-update-ebook-placeholder fieldset fieldset:has(input[name="collection-membership-sequence-number"]),
+form.create-update-ebook-placeholder fieldset fieldset:has(input[name="sequence-number-collection-name-1"]),
+form.create-update-ebook-placeholder fieldset fieldset:has(input[name="sequence-number-collection-name-2"]),
+form.create-update-ebook-placeholder fieldset fieldset:has(input[name="sequence-number-collection-name-3"]),
 form.create-update-ebook-placeholder fieldset fieldset:has(input[name="ebook-placeholder-year-published"]){
 	display: grid;
 	grid-template-columns: 200px 1fr;
@@ -34,11 +37,12 @@ form.create-update-ebook-placeholder fieldset label:has(input[type="checkbox"]){
 	grid-column: 1 / span 2;
 }
 
-form.create-update-ebook-placeholder #pd-proof > fieldset{
-	border-color: var(--body-text);
-	border-width: 3px;
-	border-style: double;
-	padding: 1rem;
+form.create-update-ebook-placeholder details{
+	margin-top: 1rem;
+}
+
+form.create-update-ebook-placeholder summary{
+	font-style: italic;
 }
 
 form.create-update-ebook-placeholder fieldset p{
@@ -54,7 +58,6 @@ form.create-update-ebook-placeholder fieldset p:first-of-type{
 form.create-update-ebook-placeholder legend{
 	font-size: 1.4rem;
 	font-family: "League Spartan", Arial, sans-serif;
-	margin-top: 2rem;
 	margin-bottom: 1rem;
 	line-height: 1.2;
 	letter-spacing: 1px;

--- a/www/ebook-placeholders/new.php
+++ b/www/ebook-placeholders/new.php
@@ -3,7 +3,7 @@ use function Safe\session_unset;
 
 session_start();
 
-$isCreated = HttpInput::Bool(SESSION, 'is-ebook-created') ?? false;
+$isCreated = HttpInput::Bool(SESSION, 'is-ebook-placeholder-created') ?? false;
 $exception = HttpInput::SessionObject('exception', Exceptions\AppException::class);
 $ebook = HttpInput::SessionObject('ebook', Ebook::class);
 
@@ -19,6 +19,7 @@ try{
 	// We got here because an ebook was successfully created.
 	if($isCreated){
 		http_response_code(Enums\HttpCode::Created->value);
+		$createdEbook = $ebook;
 		$ebook = null;
 		session_unset();
 	}
@@ -29,9 +30,7 @@ try{
 		session_unset();
 	}
 
-	if($ebook === null){
-		$ebook = new Ebook();
-	}
+	$ebook = $ebook ?? new Ebook();
 }
 catch(Exceptions\LoginRequiredException){
 	Template::RedirectToLogin();
@@ -55,8 +54,8 @@ catch(Exceptions\InvalidPermissionsException){
 
 		<?= Template::Error(['exception' => $exception]) ?>
 
-		<? if($isCreated){ ?>
-			<p class="message success">Ebook Placeholder created!</p>
+		<? if($isCreated && isset($createdEbook)){ ?>
+			<p class="message success">Ebook Placeholder created: <a href="<?= $createdEbook->Url ?>"><?= Formatter::EscapeHtml($createdEbook->Title) ?></a></p>
 		<? } ?>
 
 		<form class="create-update-ebook-placeholder" method="<?= Enums\HttpMethod::Post->value ?>" action="/ebook-placeholders" enctype="multipart/form-data" autocomplete="off">

--- a/www/ebook-placeholders/post.php
+++ b/www/ebook-placeholders/post.php
@@ -1,0 +1,111 @@
+<?
+
+try{
+	session_start();
+	$httpMethod = HttpInput::ValidateRequestMethod([Enums\HttpMethod::Post]);
+	$exceptionRedirectUrl = '/ebook-placeholders/new';
+
+	if(Session::$User === null){
+		throw new Exceptions\LoginRequiredException();
+	}
+
+	// POSTing a new ebook placeholder.
+	if($httpMethod == Enums\HttpMethod::Post){
+		if(!Session::$User->Benefits->CanCreateEbookPlaceholder){
+			throw new Exceptions\InvalidPermissionsException();
+		}
+
+		$ebook = new Ebook();
+
+		$title = HttpInput::Str(POST, 'ebook-title');
+		if(isset($title)){
+			$ebook->Title = $title;
+		}
+
+		$authors = [];
+		$authorFields = array('author-name-1', 'author-name-2', 'author-name-3');
+		foreach($authorFields as $authorField){
+			$authorName = HttpInput::Str(POST, $authorField);
+			if(!isset($authorName)){
+				continue;
+			}
+			$author = new Contributor();
+			$author->Name = $authorName;
+			$author->UrlName = Formatter::MakeUrlSafe($author->Name);
+			$author->MarcRole = Enums\MarcRole::Author;
+			$authors[] = $author;
+		}
+		$ebook->Authors = $authors;
+
+		$translators = [];
+		$translatorFields = array('translator-name-1', 'translator-name-2');
+		foreach($translatorFields as $translatorField){
+			$translatorName = HttpInput::Str(POST, $translatorField);
+			if(!isset($translatorName)){
+				continue;
+			}
+			$translator = new Contributor();
+			$translator->Name = $translatorName;
+			$translator->UrlName = Formatter::MakeUrlSafe($translator->Name);
+			$translator->MarcRole = Enums\MarcRole::Translator;
+			$translators[] = $translator;
+		}
+		$ebook->Translators = $translators;
+
+		$collectionMemberships = [];
+		$collectionNameFields = array('collection-name-1', 'collection-name-2', 'collection-name-3');
+		foreach($collectionNameFields as $collectionNameField){
+			$collectionName = HttpInput::Str(POST, $collectionNameField);
+			if(!isset($collectionName)){
+				continue;
+			}
+			$collectionSequenceNumber = HttpInput::Int(POST, 'sequence-number-' . $collectionNameField);
+			$collection = Collection::FromName($collectionName);
+
+			$cm = new CollectionMembership();
+			$cm->Collection = $collection;
+			$cm->SequenceNumber = $collectionSequenceNumber;
+			$collectionMemberships[] = $cm;
+		}
+		$ebook->CollectionMemberships = $collectionMemberships;
+
+		$ebookPlaceholder = new EbookPlaceholder();
+		$ebookPlaceholder->FillFromHttpPost();
+		$ebook->EbookPlaceholder = $ebookPlaceholder;
+
+		$ebook->FillIdentifierFromTitleAndContributors();
+		try{
+			$existingEbook = Ebook::GetByIdentifier($ebook->Identifier);
+			throw new Exceptions\DuplicateEbookException($ebook->Identifier);
+		}
+		catch(Exceptions\EbookNotFoundException){
+			// Pass and create the placeholder. There is no existing ebook with this identifier.
+		}
+
+		// These properties must be set before calling `Create()` to prevent the getters from triggering DB queries or accessing EbookId before it is set.
+		$ebook->Tags = [];
+		$ebook->LocSubjects = [];
+		$ebook->Illustrators = [];
+		$ebook->Contributors = [];
+		$ebook->Create();
+
+		$_SESSION['ebook'] = $ebook;
+		$_SESSION['is-ebook-placeholder-created'] = true;
+
+		http_response_code(Enums\HttpCode::SeeOther->value);
+		header('Location: /ebook-placeholders/new');
+	}
+}
+catch(Exceptions\LoginRequiredException){
+	Template::RedirectToLogin();
+}
+catch(Exceptions\InvalidPermissionsException | Exceptions\InvalidHttpMethodException | Exceptions\HttpMethodNotAllowedException){
+	Template::Emit403();
+}
+catch(Exceptions\AppException $ex){
+	$_SESSION['ebook'] = $ebook;
+	$_SESSION['exception'] = $ex;
+
+	http_response_code(Enums\HttpCode::SeeOther->value);
+	header('Location: ' . $exceptionRedirectUrl);
+}


### PR DESCRIPTION
The form to add ebook placeholders is usable.  Since last time:

* Updated the form to have multiple authors, translators, and collections
* Form error handling and keeping progress in the session
* The placeholders actually populate an `EbookPlaceholder` object and get written to the DB.

Here's a screenshot of what the form looks like now:

![Screenshot_2024-12-05_00-30-05](https://github.com/user-attachments/assets/2d0a4429-0b55-4c7d-8384-d3b52d9394dc)

The extra authors, translators, and collections are behind `<details>` tags. Here is what it looks like expanded:

![Screenshot_2024-12-05_00-31-23](https://github.com/user-attachments/assets/9f7cf5c1-d801-43ec-95ba-e10c5bb39071)

When you successfully create a placeholder, you're redirected back to the blank form (like the artwork form) and there's a link to the placeholder ebook:

![Screenshot_2024-12-05_00-32-45](https://github.com/user-attachments/assets/a3a69fc6-9ab7-4c94-bef1-986862273fb6)

(Clicking on that link throws errors because ebook placeholders have so many null fields. Showing placeholders is what I'll work on next. I see you did some related work for the PD 2025 books.)

#### Bulk populating the DB with SQL statements

I downloaded a CSV from Hendrik's [spreadsheet](https://docs.google.com/spreadsheets/d/1OXHJcego9CINwWSJfEAo8aTJ7jZDbhvXshYsEcMuato/edit?usp=sharing) and wrote a script to convert it into the SQL statements that will insert the placeholders in the DB. The script is basically the POST handler logic, but it reads from CSV instead of HTTP POST. You can see the SQL statments in [this file](https://gist.github.com/colagrosso/7fc986a0844157af7cd048f5f0018541#file-se-placeholders-sql), which is part of [this gist](https://gist.github.com/colagrosso/7fc986a0844157af7cd048f5f0018541) that has the script and the CSV, too. Run it like this:

```bash
 ./convert-ebook-placeholders-from-csv-to-sql > se-placeholders.sql
```

#### Updating the DB when running `deploy-ebook-to-www` works
With an empty database, I tested creating a placeholder for a known book, and then running `deploy-ebook-to-www` on the actual book. It removed the placeholder record in the DB as expected. It follows the same pattern in `Create()` and `Save()`  where we now call `RemoveEbookPlaceholder()` and `AddEbookPlaceholder()`. The published book doesn't have an `EbookPlaceholder` object, so everything works.