### PR TITLE
Show placeholders on the web

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2057,13 +2057,19 @@ class Ebook{
 	*
 	* @return array{ebooks: array<Ebook>, ebooksCount: int}
 	*/
-	public static function GetAllByFilter(string $query = null, array $tags = [], Enums\EbookSortType $sort = null, int $page = 1, int $perPage = EBOOKS_PER_PAGE): array{
+	public static function GetAllByFilter(string $query = null, array $tags = [], Enums\EbookSortType $sort = null, int $page = 1, int $perPage = EBOOKS_PER_PAGE, Enums\EbookReleaseStatusFilter $releaseStatusFilter = Enums\EbookReleaseStatusFilter::All): array{
 		$limit = $perPage;
 		$offset = (($page - 1) * $perPage);
 		$joinContributors = '';
 		$joinTags = '';
 		$params = [];
+
 		$whereCondition = 'where true';
+		if($releaseStatusFilter == Enums\EbookReleaseStatusFilter::Released){
+			$whereCondition = 'where e.WwwFilesystemPath is not null';
+		}elseif($releaseStatusFilter == Enums\EbookReleaseStatusFilter::Placeholder){
+			$whereCondition = 'where e.WwwFilesystemPath is null';
+		}
 
 		$orderBy = 'e.EbookCreated desc';
 		if($sort == Enums\EbookSortType::AuthorAlpha){

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2020,6 +2020,9 @@ class Ebook{
 	}
 
 	/**
+	 * Queries for related to books to be shown, e.g., in a carousel.
+	 *
+	 * Filters out placeholder books because they are not useful for browsing.
 	 * @return array<Ebook>
 	 */
 	public static function GetAllByRelated(Ebook $ebook, int $count, ?EbookTag $relatedTag): array{
@@ -2030,6 +2033,7 @@ class Ebook{
 						inner join EbookTags et using (EbookId)
 						where et.TagId = ?
 						    and et.EbookId != ?
+						    and e.WwwFilesystemPath is not null
 						order by rand()
 						limit ?
 				', [$relatedTag->TagId, $ebook->EbookId, $count], Ebook::class);
@@ -2039,6 +2043,7 @@ class Ebook{
 						SELECT *
 						from Ebooks
 						where EbookId != ?
+						    and WwwFilesystemPath is not null
 						order by rand()
 						limit ?
 				', [$ebook->EbookId, $count], Ebook::class);

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2075,13 +2075,13 @@ class Ebook{
 		if($sort == Enums\EbookSortType::AuthorAlpha){
 			$joinContributors = 'inner join Contributors con using (EbookId)';
 			$whereCondition .= ' and con.MarcRole = "aut"';
-			$orderBy = 'con.SortName, e.EbookCreated desc';
+			$orderBy = 'e.WwwFilesystemPath is null, con.SortName, e.EbookCreated desc'; // Put placeholders at the end
 		}
 		elseif($sort == Enums\EbookSortType::ReadingEase){
 			$orderBy = 'e.ReadingEase desc';
 		}
 		elseif($sort == Enums\EbookSortType::Length){
-			$orderBy = 'e.WordCount';
+			$orderBy = 'e.WwwFilesystemPath is null, e.WordCount'; // Put placeholders at the end
 		}
 
 		if(sizeof($tags) > 0 && !in_array('all', $tags)){ // 0 tags means "all ebooks"

--- a/lib/Enums/EbookReleaseStatusFilter.php
+++ b/lib/Enums/EbookReleaseStatusFilter.php
@@ -1,0 +1,8 @@
+<?
+namespace Enums;
+
+enum EbookReleaseStatusFilter{
+	case All;
+	case Placeholder;
+	case Released;
+}

--- a/scripts/generate-bulk-downloads
+++ b/scripts/generate-bulk-downloads
@@ -106,6 +106,10 @@ function CreateZip(string $filePath, array $ebooks, string $type, string $webRoo
 
 // Iterate over all ebooks and arrange them by publication month.
 foreach(Ebook::GetAll() as $ebook){
+	if($ebook->IsPlaceholder()){
+		continue;
+	}
+
 	$timestamp = $ebook->EbookCreated->format('Y-m');
 	$updatedTimestamp = $ebook->EbookUpdated->getTimestamp();
 

--- a/scripts/generate-feeds
+++ b/scripts/generate-feeds
@@ -100,6 +100,10 @@ foreach($dirs as $dir){
 
 // Iterate over all ebooks to build the various feeds.
 foreach(Ebook::GetAll() as $ebook){
+	if($ebook->IsPlaceholder()){
+		continue;
+	}
+
 	$allEbooks[] = $ebook;
 	$newestEbooks[] = $ebook;
 

--- a/templates/ArtworkStatus.php
+++ b/templates/ArtworkStatus.php
@@ -14,7 +14,7 @@
 			<? if($artwork->Ebook !== null && $artwork->Ebook->Url !== null){ ?>
 				<i>
 					<a href="<?= $artwork->Ebook->Url ?>"><?= Formatter::EscapeHtml($artwork->Ebook->Title) ?></a>
-				</i>
+				</i><? if($artwork->Ebook->IsPlaceholder()){ ?>(unreleased)<? } ?>
 			<? }else{ ?>
 				<code><?= Formatter::EscapeHtml($artwork->EbookUrl) ?></code> (unreleased)
 			<? } ?>

--- a/templates/EbookGrid.php
+++ b/templates/EbookGrid.php
@@ -18,11 +18,15 @@ $collection = $collection ?? null;
 			<? } ?>
 			<div class="thumbnail-container" aria-hidden="true"><? /* We need a container in case the thumb is shorter than the description, so that the focus outline doesn't take up the whole grid space */ ?>
 				<a href="<?= $ebook->Url ?>" tabindex="-1" property="schema:url"<? if($collection !== null && $ebook->GetCollectionPosition($collection) !== null){ ?> data-ordinal="<?= $ebook->GetCollectionPosition($collection) ?>"<? } ?>>
-					<picture>
-						<? if($ebook->CoverImage2xAvifUrl !== null){ ?><source srcset="<?= $ebook->CoverImage2xAvifUrl ?> 2x, <?= $ebook->CoverImageAvifUrl ?> 1x" type="image/avif"/><? } ?>
-						<source srcset="<?= $ebook->CoverImage2xUrl ?> 2x, <?= $ebook->CoverImageUrl ?> 1x" type="image/jpg"/>
-						<img src="<?= $ebook->CoverImage2xUrl ?>" alt="" property="schema:image" height="335" width="224"/>
-					</picture>
+					<? if($ebook->IsPlaceholder()){ ?>
+						<div class="placeholder-cover"></div>
+					<? }else{ ?>
+						<picture>
+							<? if($ebook->CoverImage2xAvifUrl !== null){ ?><source srcset="<?= $ebook->CoverImage2xAvifUrl ?> 2x, <?= $ebook->CoverImageAvifUrl ?> 1x" type="image/avif"/><? } ?>
+							<source srcset="<?= $ebook->CoverImage2xUrl ?> 2x, <?= $ebook->CoverImageUrl ?> 1x" type="image/jpg"/>
+							<img src="<?= $ebook->CoverImage2xUrl ?>" alt="" property="schema:image" height="335" width="224"/>
+						</picture>
+					<? } ?>
 				</a>
 			</div>
 			<p><a href="<?= $ebook->Url ?>" property="schema:url"><span property="schema:name"><?= Formatter::EscapeHtml($ebook->Title) ?></span></a></p>

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1572,6 +1572,23 @@ ol.ebooks-list > li p.author a{
 	justify-content: center;
 }
 
+.placeholder-cover {
+	align-items: center;
+	background-color: #282828;
+	background-image: url("/images/stripes-xdark.svg");
+	border-radius: .25rem;
+	border: 1px solid var(--border);
+	display: flex;
+	height: 335px;
+	justify-content: center;
+	width: 224px;
+}
+
+.placeholder-cover::before {
+	content: "Placeholder";
+	font-size: .6rem;
+}
+
 article nav ol,
 main nav.pagination ol{
 	list-style: none;

--- a/www/ebook-placeholders/get.php
+++ b/www/ebook-placeholders/get.php
@@ -1,0 +1,118 @@
+<?
+
+use function Safe\preg_replace;
+
+/** @var string $identifier Passed from script this is included from. */
+$ebook = null;
+
+$ebook = null;
+
+try{
+	$ebook = Ebook::GetByIdentifier($identifier);
+}
+catch(Exceptions\EbookNotFoundException){
+	Template::Emit404();
+}
+?><?= Template::Header(
+	[
+		'title' => strip_tags($ebook->TitleWithCreditsHtml),
+		'css' => ['/css/ebook-placeholder.css'],
+		'highlight' => 'ebooks',
+		'canonicalUrl' => SITE_URL . $ebook->Url
+	])
+?>
+<main>
+	<article class="ebook" typeof="schema:Book" about="<?= $ebook->Url ?>">
+		<header>
+			<hgroup>
+				<h1 property="schema:name"><?= Formatter::EscapeHtml($ebook->Title) ?></h1>
+				<? foreach($ebook->Authors as $author){ ?>
+					<?
+						/* We include the `resource` attr here because we can have multiple authors, and in that case their href URLs will link to their combined corpus.
+
+						For example, William Wordsworth & Samuel Coleridge will both link to `/ebooks/william-wordsworth_samuel-taylor-coleridge`.
+
+						But, each author is an individual, so we have to differentiate them in RDFa with `resource`.
+					*/ ?>
+					<? if($author->Name != 'Anonymous'){ ?>
+						<h2>
+							<a property="schema:author" typeof="schema:Person" href="<?= Formatter::EscapeHtml($ebook->AuthorsUrl) ?>" resource="<?= '/ebooks/' . $author->UrlName ?>">
+								<span property="schema:name"><?= Formatter::EscapeHtml($author->Name) ?></span>
+								<meta property="schema:url" content="<?= SITE_URL . Formatter::EscapeHtml($ebook->AuthorsUrl) ?>"/>
+								<? if($author->NacoafUrl){ ?>
+									<meta property="schema:sameAs" content="<?= Formatter::EscapeHtml($author->NacoafUrl) ?>"/>
+								<? } ?>
+								<? if($author->WikipediaUrl){ ?>
+									<meta property="schema:sameAs" content="<?= Formatter::EscapeHtml($author->WikipediaUrl) ?>"/>
+								<? } ?>
+							</a>
+						</h2>
+					<? } ?>
+				<? } ?>
+			</hgroup>
+			<picture>
+				<source srcset="/images/public-domain-day-placeholder-cover-hero@2x.jpg 2x, /images/public-domain-day-placeholder-cover-hero.jpg 1x" type="image/jpg"/>
+				<img src="/images/public-domain-day-placeholder-cover-hero@2x.jpg" alt="" height="439" width="1318" />
+			</picture>
+		</header>
+
+
+		<aside id="reading-ease">
+			<? if($ebook->ContributorsHtml != ''){ ?>
+				<p><?= $ebook->ContributorsHtml ?></p>
+			<? } ?>
+			<? if(sizeof($ebook->CollectionMemberships) > 0){ ?>
+				<? foreach($ebook->CollectionMemberships as $collectionMembership){ ?>
+					<? $collection = $collectionMembership->Collection; ?>
+					<? $sequenceNumber = $collectionMembership->SequenceNumber; ?>
+					<p>
+						<? if($sequenceNumber !== null){ ?>№ <?= number_format($sequenceNumber) ?> in the<? }else{ ?>Part of the<? } ?> <a href="<?= $collection->Url ?>" property="schema:isPartOf"><?= Formatter::EscapeHtml(preg_replace('/^The /ius', '', (string)$collection->Name)) ?></a>
+						<? if($collection->Type !== null){ ?>
+							<? if(substr_compare(mb_strtolower($collection->Name), mb_strtolower($collection->Type->value), -strlen(mb_strtolower($collection->Type->value))) !== 0){ ?>
+								<?= $collection->Type->value ?>.
+							<? } ?>
+						<? }else{ ?>
+							collection.
+						<? } ?>
+					</p>
+				<? } ?>
+			<? } ?>
+		</aside>
+
+		<section>
+			<h2>Raw placeholder data</h2>
+			<table>
+				<tr>
+					<td>Year published</td>
+					<td><?= $ebook->EbookPlaceholder->YearPublished ?></td>
+				</tr>
+				<tr>
+					<td>IsWanted</td>
+					<td><?= $ebook->EbookPlaceholder->IsWanted ?></td>
+				</tr>
+				<tr>
+					<td>Status</td>
+					<td><? if(isset($ebook->EbookPlaceholder->Status)){ ?><?= $ebook->EbookPlaceholder->Status->value ?><? } ?></td>
+				</tr>
+				<tr>
+					<td>Difficulty</td>
+					<td><? if(isset($ebook->EbookPlaceholder->Difficulty)){ ?><?= $ebook->EbookPlaceholder->Difficulty->value ?><? } ?></td>
+				</tr>
+				<tr>
+					<td>Transcription Url</td>
+					<td><?= $ebook->EbookPlaceholder->TranscriptionUrl ?></td>
+				</tr>
+				<tr>
+					<td>IsPatron</td>
+					<td><?= $ebook->EbookPlaceholder->IsPatron ?></td>
+				</tr>
+				<tr>
+					<td>Notes</td>
+					<td><? if(isset($ebook->EbookPlaceholder->Notes)){ ?><?= Formatter::MarkdownToHtml($ebook->EbookPlaceholder->Notes) ?><? } ?></td>
+				</tr>
+			</table>
+		</section>
+
+	</article>
+</main>
+<?= Template::Footer() ?>

--- a/www/ebooks/download.php
+++ b/www/ebooks/download.php
@@ -13,6 +13,10 @@ try{
 	$identifier = EBOOKS_IDENTIFIER_PREFIX . $urlPath;
 	$ebook = Ebook::GetByIdentifier($identifier);
 
+	if($ebook->IsPlaceholder()){
+		throw new Exceptions\InvalidFileException();
+	}
+
 	$format = Enums\EbookFormatType::tryFrom(HttpInput::Str(GET, 'format') ?? '') ?? Enums\EbookFormatType::Epub;
 	switch($format){
 		case Enums\EbookFormatType::Kepub:

--- a/www/ebooks/get.php
+++ b/www/ebooks/get.php
@@ -19,6 +19,11 @@ try{
 
 	$ebook = Ebook::GetByIdentifier($identifier);
 
+	if($ebook->IsPlaceholder()){
+		require('/standardebooks.org/web/www/ebook-placeholders/get.php');
+		exit();
+	}
+
 	// Divide our sources into transcriptions and scans.
 	foreach($ebook->Sources as $source){
 		switch($source->Type){

--- a/www/ebooks/index.php
+++ b/www/ebooks/index.php
@@ -34,7 +34,7 @@ try{
 		$tags = [];
 	}
 
-	$result = Ebook::GetAllByFilter($query != '' ? $query : null, $tags, $sort, $page, $perPage);
+	$result = Ebook::GetAllByFilter($query != '' ? $query : null, $tags, $sort, $page, $perPage, Enums\EbookReleaseStatusFilter::All);
 	$ebooks = $result['ebooks'];
 	$totalEbooks = $result['ebooksCount'];
 	$pageTitle = 'Browse Standard Ebooks';

--- a/www/feeds/atom/search.php
+++ b/www/feeds/atom/search.php
@@ -7,7 +7,7 @@ try{
 	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count)['ebooks'];
+		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count, Enums\EbookReleaseStatusFilter::Released)['ebooks'];
 	}
 }
 catch(\Exception){

--- a/www/feeds/opds/search.php
+++ b/www/feeds/opds/search.php
@@ -7,7 +7,7 @@ try{
 	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count)['ebooks'];
+		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count, Enums\EbookReleaseStatusFilter::Released)['ebooks'];
 	}
 }
 catch(\Exception){

--- a/www/feeds/rss/search.php
+++ b/www/feeds/rss/search.php
@@ -7,7 +7,7 @@ try{
 	$count = HttpInput::Int(GET, 'per-page') ?? EBOOKS_PER_PAGE;
 
 	if($query !== ''){
-		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count)['ebooks'];
+		$ebooks = Ebook::GetAllByFilter($query, [], Enums\EbookSortType::Newest, $startPage, $count, Enums\EbookReleaseStatusFilter::Released)['ebooks'];
 	}
 }
 catch(\Exception){


### PR DESCRIPTION
These look pretty bad (even for me), but it's minimal styling. I trust you can make them look better. Here are screenshots of:

Search results:
![Screenshot_2024-12-09_10-08-46](https://github.com/user-attachments/assets/30c0a2b1-6ecd-423e-bfde-2c285439519c)

Collections page:
![Screenshot_2024-12-09_09-09-28](https://github.com/user-attachments/assets/06fceb14-9f7b-4057-a588-a662923fb366)

Author page:
![Screenshot_2024-12-09_10-09-59](https://github.com/user-attachments/assets/40d55d89-0f96-4083-aeda-47e25a4d40e6)

Single ebook placeholder:
![Screenshot_2024-12-08_16-13-46](https://github.com/user-attachments/assets/adf6ff90-eb00-4753-9dab-69bb8d42d592)

Here are assumptions I made that I'd like you to check:

### Placeholders are ok in
* Search results
* Collections page
* Author page
* Single book
    * `www/ebooks/get.php` checks `Ebook::IsPlaceholder()` and does `require www/ebook-placeholders/get.php`
* Sitemap
* Artwork page
    * If an artwork is assigned to a placeholder, the link now works, but it still reads "(unreleased)" after the link

### Placeholders are NOT ok in
* The related books carousel at the bottom of `www/ebooks/get.php`
   * Removed placeholders from the query in `Ebook::GetAllByRelated()`
* `scripts/generate-bulk-downloads` and `scripts/generate-feeds`
    * The scripts post-filter by checking `Ebook::IsPlaceholder()` after calling `Ebook::GetAll()`
* Feeds search (e.g., `www/feeds/opds/search.php`)
    * Added a filter parameter to `Ebook::GetAllByFilter()` to filter out placeholders
* `www/ebooks/download.php`
    * This would be rare because the user would have to add `/download` to a placeholder URL, but the code checks `Ebook::IsPlaceholder()` after calling `Ebook::GetByIdentifier()`