### PR TITLE
Hide placeholders when browsing /ebooks without a search query

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -1338,6 +1338,7 @@ class Ebook{
 
 	/**
 	 * @throws Exceptions\ValidationException
+	 * @throws Exceptions\DuplicateEbookException
 	 */
 	public function CreateOrUpdate(): void{
 		try{

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2076,11 +2076,23 @@ class Ebook{
 		$joinTags = '';
 		$params = [];
 
-		$whereCondition = 'where true';
-		if($releaseStatusFilter == Enums\EbookReleaseStatusFilter::Released){
-			$whereCondition = 'where e.WwwFilesystemPath is not null';
-		}elseif($releaseStatusFilter == Enums\EbookReleaseStatusFilter::Placeholder){
-			$whereCondition = 'where e.WwwFilesystemPath is null';
+		switch($releaseStatusFilter){
+			case Enums\EbookReleaseStatusFilter::Released:
+				$whereCondition = 'where e.WwwFilesystemPath is not null';
+				break;
+			case Enums\EbookReleaseStatusFilter::Placeholder:
+				$whereCondition = 'where e.WwwFilesystemPath is null';
+				break;
+			case Enums\EbookReleaseStatusFilter::All:
+			default:
+				if($query !== null && $query != ''){
+					// If the query is present, show both released and placeholder ebooks.
+					$whereCondition = 'where true';
+				}else{
+					// If there is no query, hide placeholder ebooks.
+					$whereCondition = 'where e.WwwFilesystemPath is not null';
+				}
+				break;
 		}
 
 		$orderBy = 'e.EbookCreated desc';

--- a/www/ebook-placeholders/get.php
+++ b/www/ebook-placeholders/get.php
@@ -80,7 +80,7 @@ catch(Exceptions\EbookNotFoundException){
 				<p>This book was published in <?= $ebook->EbookPlaceholder->YearPublished ?>, and will therefore enter the U.S. public domain on <b>January 1, <?= $ebook->EbookPlaceholder->YearPublished + 96 ?>.</b></p>
 				<p>We can’t work on it any earlier than that.</p>
 			<? }else{ ?>
-				<p>This book is not yet in the U.S. public domain. We can’t offer it it until it is.</p>
+				<p>This book is not yet in the U.S. public domain. We can’t offer it until it is.</p>
 			<? } ?>
 		</section>
 	</article>


### PR DESCRIPTION
As mentioned [here](https://github.com/standardebooks/web/issues/430#issuecomment-2536869091) in #430:

> Another thing I noticed is that placeholders appear in `/ebooks` when no search parameters are set. I think we should not show placeholders in that case - only if the user has actually entered some parameters in the search form.

This PR hides the placeholders when there is no search query. That's the only search parameter worth considering. Placeholders don't have tags, and changing the Sort, View, or Per page parameters shouldn't change whether placeholders appear. 

Two other minor commits in this PR.