### PR TITLE
Style placeholders for list view

### DIFF
--- a/templates/EbookGrid.php
+++ b/templates/EbookGrid.php
@@ -46,8 +46,10 @@ $collection = $collection ?? null;
 							<p><?= rtrim($ebook->ContributorsHtml, '.') ?></p>
 						</div>
 					<? } ?>
-					<p><?= number_format($ebook->WordCount) ?> words • <?= $ebook->ReadingEase ?> reading ease</p>
-					<ul class="tags"><? foreach($ebook->Tags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::EscapeHtml($tag->Name) ?></a></li><? } ?></ul>
+					<? if(!$ebook->IsPlaceholder()){ ?>
+						<p><?= number_format($ebook->WordCount) ?> words • <?= $ebook->ReadingEase ?> reading ease</p>
+						<ul class="tags"><? foreach($ebook->Tags as $tag){ ?><li><a href="<?= $tag->Url ?>"><?= Formatter::EscapeHtml($tag->Name) ?></a></li><? } ?></ul>
+					<? } ?>
 				</div>
 			<? } ?>
 		</li>

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -1580,6 +1580,11 @@ ol.ebooks-list > li p.author a{
 	width: 221px;
 }
 
+ol.ebooks-list.list .placeholder-cover{
+	height: 191px;
+	width: 126px;
+}
+
 article nav ol,
 main nav.pagination ol{
 	list-style: none;


### PR DESCRIPTION
Before
![Screenshot_2024-12-12_17-49-45](https://github.com/user-attachments/assets/977c60a8-926b-482f-82bd-0ba285ae69fb)

After
![Screenshot_2024-12-12_17-50-35](https://github.com/user-attachments/assets/e319ac37-dd47-4e2d-acd7-05745e9ad35f)

Still room for improvement in `templates/EbookGrid.php`, but this is better for list view.