### PR TITLE
Allow author paths that don't point to www files

### DIFF
--- a/www/authors/get.php
+++ b/www/authors/get.php
@@ -5,10 +5,8 @@ $authorUrl = '';
 
 try{
 	$urlPath = trim(str_replace('.', '', HttpInput::Str(GET, 'url-path') ?? ''), '/'); // Contains the portion of the URL (without query string) that comes after `https://standardebooks.org/ebooks/`.
-	$wwwFilesystemPath = EBOOKS_DIST_PATH . $urlPath; // Path to the deployed www files for this ebook.
 
-	if($urlPath == '' || mb_stripos($wwwFilesystemPath, EBOOKS_DIST_PATH) !== 0 || !is_dir($wwwFilesystemPath)){
-		// Ensure the path exists and that the root is in our www directory.
+	if($urlPath == ''){
 		throw new Exceptions\AuthorNotFoundException();
 	}
 


### PR DESCRIPTION
Authors with placeholders only, e.g. (at the time of writing):

https://standardebooks.org/ebooks/dashiell-hammet

were returning 404s because there was no directory at:

/standardebooks.org/web/www/ebooks/dashiell-hammet

Now we allow calls to `Ebook::GetAllByAuthor()` for such URLs because it might find placeholders for the author.