### PR TITLE
Nudge the placeholder ribbon left 2px, past the border

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -3278,6 +3278,15 @@ ol.ebooks-list > li[property="schema:hasPart"][value].ribbon a::after{
 	top: calc(.25rem + 3px + 2rem + 4px);
 }
 
+ol.ebooks-list > li.ribbon .placeholder-cover::before, /* Ribbon */
+ol.ebooks-list > li.ribbon .placeholder-cover::after{ /* Ribbon bottom wrap-around */
+	left: calc(-.5rem - 2px); /* Subtract 2px from the rules above to account for the placeholder's border. */
+}
+
+ol.ebooks-list > li.ribbon a:has(.placeholder-cover)::after { /* Ribbon shadow */
+	left: calc(-.5rem + 2px); /* Subtract 2px from the rule above (-.5rem + 4px) to account for the placeholder's border. */
+}
+
 ol.ebooks-list > li.ribbon.wanted .placeholder-cover::before,
 ol.ebooks-list > li.ribbon.wanted .placeholder-cover::after{
 	background: #383760;


### PR DESCRIPTION
To my eye, the ribbon should fold against the outside edge of the border.

Before:
![Screenshot_2024-12-16_00-16-20](https://github.com/user-attachments/assets/ee43a172-9c28-450b-895b-c899c85ba1fc)

After:
![Screenshot_2024-12-16_00-20-05](https://github.com/user-attachments/assets/52bef309-cea5-471e-86f0-cc3d6b7b3f8e)



(The "In Use" ribbon on artwork looks right because it's placed on a higher element, before the border is applied.)