### PR TITLE
Add /edit endpoint to update placeholders

### DIFF
--- a/config/apache/rewrites/ebooks.conf
+++ b/config/apache/rewrites/ebooks.conf
@@ -19,6 +19,12 @@ RewriteRule	^/collections/([^\./]+?)$		/collections/get.php?collection=$1 [QSA]
 RewriteRule	^/collections/([^/]+?)/downloads$	/bulk-downloads/get.php?collection=$1
 RewriteRule	^/collections/([^/]+?)/feeds$		/feeds/get.php?collection=$1
 
+# Edit rewrites
+RewriteRule	^/ebooks/(.+?)/edit$			/ebooks/edit.php?url-path=$1 [L]
+
+RewriteCond	expr "tolower(%{REQUEST_METHOD}) =~ /^post$/"
+RewriteRule	^/ebooks/([^\.]+?)$			/ebooks/post.php?url-path=$1 [L]
+
 # List of specific URL rewrites
 RewriteRule	^/contribute/accepted-ebooks/?														/contribute/collections-policy [R=301,L]
 RewriteRule	^/ebooks/aristotle/the-nicomachean-ethics(/?$|/.+?$)											/ebooks/aristotle/nicomachean-ethics$1 [R=301,L]

--- a/www/ebook-placeholders/edit.php
+++ b/www/ebook-placeholders/edit.php
@@ -1,0 +1,64 @@
+<?
+use function Safe\session_unset;
+
+session_start();
+
+
+$exception = HttpInput::SessionObject('exception', Exceptions\AppException::class);
+
+/** @var string $identifier Passed from script this is included from. */
+$ebook = HttpInput::SessionObject('ebook', Ebook::class);
+
+try{
+	if(Session::$User === null){
+		throw new Exceptions\LoginRequiredException();
+	}
+
+	if(!Session::$User->Benefits->CanEditEbookPlaceholders){
+		throw new Exceptions\InvalidPermissionsException();
+	}
+
+	if($ebook === null){
+		$ebook = Ebook::GetByIdentifier($identifier);
+	}
+
+	if(!$ebook->IsPlaceholder() || $ebook->EbookPlaceholder === null){
+		throw new Exceptions\EbookNotFoundException();
+	}
+
+	if($exception){
+		http_response_code(Enums\HttpCode::UnprocessableContent->value);
+		session_unset();
+	}
+}
+catch(Exceptions\EbookNotFoundException){
+	Template::Emit404();
+}
+catch(Exceptions\LoginRequiredException){
+	Template::RedirectToLogin();
+}
+catch(Exceptions\InvalidPermissionsException){
+	Template::Emit403();
+}
+?>
+<?= Template::Header(
+	[
+		'title' => 'Edit Ebook Placeholder for ' . $ebook->Title,
+		'css' => ['/css/ebook-placeholder.css'],
+		'highlight' => '',
+		'description' => 'Edit the ebook placeholder for ' . $ebook->Title
+	]
+) ?>
+<main>
+	<section class="narrow">
+		<h1>Edit Ebook Placeholder</h1>
+
+		<?= Template::Error(['exception' => $exception]) ?>
+
+		<form class="create-update-ebook-placeholder" method="<?= Enums\HttpMethod::Post->value ?>" action="<?= $ebook->Url ?>" autocomplete="off">
+			<input type="hidden" name="_method" value="<?= Enums\HttpMethod::Put->value ?>" />
+			<?= Template::EbookPlaceholderForm(['ebook' => $ebook]) ?>
+		</form>
+	</section>
+</main>
+<?= Template::Footer() ?>

--- a/www/ebook-placeholders/get.php
+++ b/www/ebook-placeholders/get.php
@@ -1,14 +1,23 @@
 <?
 use function Safe\preg_replace;
+use function Safe\session_unset;
+
+session_start();
 
 /** @var string $identifier Passed from script this is included from. */
 $ebook = null;
+
+$isSaved = HttpInput::Bool(SESSION, 'is-ebook-placeholder-saved') ?? false;
 
 try{
 	$ebook = Ebook::GetByIdentifier($identifier);
 
 	if($ebook->EbookPlaceholder === null){
 		throw new Exceptions\EbookNotFoundException();
+	}
+
+	if($isSaved){
+		session_unset();
 	}
 }
 catch(Exceptions\EbookNotFoundException){
@@ -52,6 +61,10 @@ catch(Exceptions\EbookNotFoundException){
 				<? } ?>
 			</hgroup>
 		</header>
+
+		<? if($isSaved){ ?>
+			<p class="message success">Ebook Placeholder saved!</p>
+		<? } ?>
 
 		<aside id="reading-ease">
 			<? if($ebook->ContributorsHtml != ''){ ?>
@@ -108,6 +121,11 @@ catch(Exceptions\EbookNotFoundException){
 
 		<? if(Session::$User?->Benefits->CanEditProjects || Session::$User?->Benefits->CanManageProjects || Session::$User?->Benefits->CanReviewProjects){ ?>
 			<?= Template::EbookProjects(['ebook' => $ebook, 'showAddButton' => Session::$User->Benefits->CanEditProjects && $ebook->ProjectInProgress === null]) ?>
+		<? } ?>
+
+		<? if(Session::$User?->Benefits->CanEditEbookPlaceholders){ ?>
+			<h2>Edit ebook placeholder</h2>
+			<p><a href="<?= $ebook->EditUrl ?>">Edit this ebook placeholder.</a></p>
 		<? } ?>
 	</article>
 </main>

--- a/www/ebooks/edit.php
+++ b/www/ebooks/edit.php
@@ -1,0 +1,35 @@
+<?
+
+$ebook = null;
+
+try{
+	if(Session::$User === null){
+		throw new Exceptions\LoginRequiredException();
+	}
+
+	if(!Session::$User->Benefits->CanEditEbookPlaceholders){
+		throw new Exceptions\InvalidPermissionsException();
+	}
+
+	$identifier = EBOOKS_IDENTIFIER_PREFIX .  trim(str_replace('.', '', HttpInput::Str(GET, 'url-path') ?? ''), '/');
+
+	$ebook = Ebook::GetByIdentifier($identifier);
+
+	if($ebook->IsPlaceholder()){
+		require('/standardebooks.org/web/www/ebook-placeholders/edit.php');
+		exit();
+	}
+
+	// Editing published `Ebooks` is not supported.
+	Template::Emit404();
+}
+catch(Exceptions\EbookNotFoundException){
+	Template::Emit404();
+}
+catch(Exceptions\LoginRequiredException){
+	Template::RedirectToLogin();
+}
+catch(Exceptions\InvalidPermissionsException){
+	Template::Emit403();
+}
+

--- a/www/ebooks/post.php
+++ b/www/ebooks/post.php
@@ -1,0 +1,35 @@
+<?
+
+$ebook = null;
+
+try{
+	if(Session::$User === null){
+		throw new Exceptions\LoginRequiredException();
+	}
+
+	if(!Session::$User->Benefits->CanEditEbookPlaceholders){
+		throw new Exceptions\InvalidPermissionsException();
+	}
+
+	$identifier = EBOOKS_IDENTIFIER_PREFIX .  trim(str_replace('.', '', HttpInput::Str(GET, 'url-path') ?? ''), '/');
+
+	$ebook = Ebook::GetByIdentifier($identifier);
+
+	if($ebook->IsPlaceholder()){
+		require('/standardebooks.org/web/www/ebook-placeholders/post.php');
+		exit();
+	}
+
+	// POSTing published `Ebooks` is not supported.
+	Template::Emit404();
+}
+catch(Exceptions\EbookNotFoundException){
+	Template::Emit404();
+}
+catch(Exceptions\LoginRequiredException){
+	Template::RedirectToLogin();
+}
+catch(Exceptions\InvalidPermissionsException){
+	Template::Emit403();
+}
+


### PR DESCRIPTION
I tested this a few ways, but there is a lot going on with `Ebook`, `EbookPlaceholder`, and `Project` objects. The `PUT` section in `www/ebook-placeholders/post.php` could benefit from an extra look to make sure it's doing what you want with `Project` objects.

One simple case that works well and you can use on the production site is to correct this placeholder:

https://standardebooks.org/ebooks/dashiell-hammet/the-maltese-falcon

to "Hammett" with two "t"s. It was wrong in the spreadsheet, but Hendrik must have corrected it recently. 

![Screenshot_2024-12-17_21-10-49](https://github.com/user-attachments/assets/d8c2119d-546a-4334-897e-0324ef2d68d7)
