### PR TITLE
Make `DeleteUnused()` faster for `Collection`, `Tag`, and `LocSubject`

### DIFF
--- a/config/sql/se/CollectionEbooks.sql
+++ b/config/sql/se/CollectionEbooks.sql
@@ -3,5 +3,6 @@ CREATE TABLE IF NOT EXISTS `CollectionEbooks` (
   `CollectionId` int(10) unsigned NOT NULL,
   `SequenceNumber` int(10) unsigned NULL,
   `SortOrder` tinyint(3) unsigned NOT NULL,
-  UNIQUE KEY `idxUnique` (`EbookId`,`CollectionId`)
+  UNIQUE KEY `idxUnique` (`EbookId`,`CollectionId`),
+  KEY `index1` (`CollectionId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/config/sql/se/EbookLocSubjects.sql
+++ b/config/sql/se/EbookLocSubjects.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS `EbookLocSubjects` (
   `EbookId` int(10) unsigned NOT NULL,
   `LocSubjectId` int(10) unsigned NOT NULL,
   `SortOrder` tinyint(3) unsigned NOT NULL,
-  UNIQUE KEY `idxUnique` (`EbookId`,`LocSubjectId`)
+  UNIQUE KEY `idxUnique` (`EbookId`,`LocSubjectId`),
+  KEY `index1` (`LocSubjectId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/config/sql/se/EbookTags.sql
+++ b/config/sql/se/EbookTags.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS `EbookTags` (
   `EbookId` int(10) unsigned NOT NULL,
   `TagId` int(10) unsigned NOT NULL,
   `SortOrder` tinyint(3) unsigned NOT NULL,
-  UNIQUE KEY `idxUnique` (`EbookId`,`TagId`)
+  UNIQUE KEY `idxUnique` (`EbookId`,`TagId`),
+  KEY `index1` (`TagId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -104,10 +104,10 @@ class Collection{
 	 */
 	public static function DeleteUnused(): void{
 		Db::Query('
-			DELETE
-			from Collections
-			where CollectionId not in
-				(select distinct CollectionId from CollectionEbooks)
+			DELETE c
+			from Collections c
+				left join CollectionEbooks ce using (CollectionId)
+			where ce.CollectionId is null
 		');
 	}
 

--- a/lib/EbookTag.php
+++ b/lib/EbookTag.php
@@ -113,11 +113,11 @@ class EbookTag extends Tag{
 	 */
 	public static function DeleteUnused(): void{
 		Db::Query('
-			DELETE
-			from Tags
-			where Type = ?
-				and TagId not in
-					(select distinct TagId from EbookTags)
+			DELETE t
+			from Tags t 
+				left join EbookTags et using (TagId)
+			where t.Type = ?
+				and et.TagId is null
 		', [Enums\TagType::Ebook]);
 	}
 }

--- a/lib/LocSubject.php
+++ b/lib/LocSubject.php
@@ -70,10 +70,10 @@ class LocSubject{
 	 */
 	public static function DeleteUnused(): void{
 		Db::Query('
-			DELETE
-			from LocSubjects
-			where LocSubjectId not in
-				(select distinct LocSubjectId from EbookLocSubjects)
+			DELETE ls
+			from LocSubjects ls
+				left join EbookLocSubjects els using (LocSubjectId)
+			where els.LocSubjectId is null
 		');
 	}
 }


### PR DESCRIPTION
I think the new query is readable, so I applied it to all three types.

You'll need to add these three indices to your DB:

```sql
ALTER TABLE `CollectionEbooks` ADD INDEX `index1` (`CollectionId`);
ALTER TABLE `EbookLocSubjects` ADD INDEX `index1` (`LocSubjectId`);
ALTER TABLE `EbookTags` ADD INDEX `index1` (`TagId`);
```

It runs much faster on my underpowered machine. When running just `Ebook::Save()` via:

```
$ time nice /standardebooks.org/web/scripts/deploy-ebook-to-www --verbose --no-build --no-images --no-recompose --no-epubcheck --no-feeds --no-bulk-downloads virginia-woolf_to-the-lighthouse.git
```

here are the before and after times:

Before:
```
real    0m1.682s
user    0m0.086s
sys     0m0.071s
```

After:
```
real    0m0.267s
user    0m0.085s
sys     0m0.067s
```

Here are the explain plans before and after adding the index to `EbookLocSubjects`:

```
explain delete ls from LocSubjects ls LEFT JOIN EbookLocSubjects els ON ls.LocSubjectId = els.LocSubjectId WHERE els.LocSubjectId IS NULL;
```

Before:
```
+------+-------------+-------+-------+---------------+-----------+---------+------+------+--------------------------------------+
| id   | select_type | table | type  | possible_keys | key       | key_len | ref  | rows | Extra                                |
+------+-------------+-------+-------+---------------+-----------+---------+------+------+--------------------------------------+
|    1 | SIMPLE      | ls    | ALL   | NULL          | NULL      | NULL    | NULL | 1937 |                                      |
|    1 | SIMPLE      | els   | index | NULL          | idxUnique | 8       | NULL | 8228 | Using where; Using index; Not exists |
+------+-------------+-------+-------+---------------+-----------+---------+------+------+--------------------------------------+

```

After:
```
+------+-------------+-------+------+---------------+--------+---------+--------------------+------+--------------------------------------+
| id   | select_type | table | type | possible_keys | key    | key_len | ref                | rows | Extra                                |
+------+-------------+-------+------+---------------+--------+---------+--------------------+------+--------------------------------------+
|    1 | SIMPLE      | ls    | ALL  | NULL          | NULL   | NULL    | NULL               | 1937 |                                      |
|    1 | SIMPLE      | els   | ref  | index1        | index1 | 4       | se.ls.LocSubjectId | 2    | Using where; Using index; Not exists |
+------+-------------+-------+------+---------------+--------+---------+--------------------+------+--------------------------------------+
```
