### PR TITLE
Rewrite `MultiTableSelect` queries with `ON`

### DIFF
--- a/config/sql/se/Projects.sql
+++ b/config/sql/se/Projects.sql
@@ -15,5 +15,6 @@ CREATE TABLE IF NOT EXISTS `Projects` (
   `LastCommitTimestamp` DATETIME NULL DEFAULT NULL,
   `LastDiscussionTimestamp` DATETIME NULL DEFAULT NULL,
   `IsStatusAutomaticallyUpdated` tinyint(1) NOT NULL DEFAULT 1,
-  PRIMARY KEY (`ProjectId`)
+  PRIMARY KEY (`ProjectId`),
+  KEY `index1` (`EbookId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/lib/DbConnection.php
+++ b/lib/DbConnection.php
@@ -109,7 +109,7 @@ class DbConnection{
 	/**
 	 * Execute a select query that returns a join against multiple tables.
 	 *
-	 * For example, `select * from Users inner join Posts using (UserId)`.
+	 * For example, `select * from Users inner join Posts on Users.UserId = Posts.UserId`.
 	 *
 	 * The result is an array of rows. Each row is an array of objects, with each object containing its columns and values. For example,
 	 *
@@ -122,6 +122,7 @@ class DbConnection{
 	 *		},
 	 *		'Posts' => {
 	 *			'PostId' => 222,
+	 *			'UserId' => 111,
 	 *			'Title' => 'Lorem Ipsum'
 	 *		}
 	 *	],
@@ -132,13 +133,14 @@ class DbConnection{
 	 *		},
 	 *		'Posts' => {
 	 *			'PostId' => 444,
+	 *			'UserId' => 333,
 	 *			'Title' => 'Dolor sit'
 	 *		}
 	 *	]
 	 *  ]
 	 * ```
 	 *
-	 * **Important note:** When joining against two tables, SQL only returns one column for the join key (typically an ID value). Therefore, if both objects require an ID, the filler method must explicitly assign the ID to one of the two objects that's missing it. The above example shows this behavior: note how we join on `UserId`, but only the `Users` result has the `UserId` column, even though the `Posts` table also has a `UserId` column.
+	 * **Important note:** If the two tables above were joined via `using (UserId)` instead of `on Users.UserId = Posts.UserId`, the SQL query would return only one column for the join key (`UserId` in this case). Therefore, if both objects require an ID, the filler method must explicitly assign the ID to one of the two objects that's missing it. In the above example, the `Users` result would have the `UserId` column, and `Posts` would not.
 	 *
 	 * @template T
 	 *

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -164,8 +164,8 @@ final class Ebook{
 							SELECT *
 							from Projects
 							inner join Ebooks
-							using(EbookId)
-							where EbookId = ?
+							on Projects.EbookId = Ebooks.EbookId
+							where Ebooks.EbookId = ?
 							order by Projects.Created desc
 						', [$this->EbookId], Project::class);
 		}
@@ -183,8 +183,8 @@ final class Ebook{
 								SELECT *
 								from Projects
 								inner join Ebooks
-								using(EbookId)
-								where EbookId = ?
+								on Projects.EbookId = Ebooks.EbookId
+								where Ebooks.EbookId = ?
 								and Status in (?, ?)
 							', [$this->EbookId, Enums\ProjectStatusType::InProgress, Enums\ProjectStatusType::Stalled], Project::class)[0] ?? null;
 			}
@@ -206,8 +206,8 @@ final class Ebook{
 								SELECT *
 								from Projects
 								inner join Ebooks
-								using(EbookId)
-								where EbookId = ?
+								on Projects.EbookId = Ebooks.EbookId
+								where Ebooks.EbookId = ?
 								and Status in (?, ?)
 							', [$this->EbookId, Enums\ProjectStatusType::Completed, Enums\ProjectStatusType::Abandoned], Project::class);
 			}

--- a/lib/Project.php
+++ b/lib/Project.php
@@ -660,21 +660,21 @@ final class Project{
 	 * @return array<Project>
 	 */
 	public static function GetAllByStatus(Enums\ProjectStatusType $status): array{
-		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks using (EbookId) where Projects.Status = ? order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$status], Project::class);
+		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks on Projects.EbookId = Ebooks.EbookId where Projects.Status = ? order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$status], Project::class);
 	}
 
 	/**
 	 * @return array<Project>
 	 */
 	public static function GetAllByManagerUserId(int $userId): array{
-		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks using (EbookId) where ManagerUserId = ? and Status in (?, ?) order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$userId, Enums\ProjectStatusType::InProgress, Enums\ProjectStatusType::Stalled], Project::class);
+		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks on Projects.EbookId = Ebooks.EbookId where ManagerUserId = ? and Status in (?, ?) order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$userId, Enums\ProjectStatusType::InProgress, Enums\ProjectStatusType::Stalled], Project::class);
 	}
 
 	/**
 	 * @return array<Project>
 	 */
 	public static function GetAllByReviewerUserId(int $userId): array{
-		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks using (EbookId) where ReviewerUserId = ? and Status in (?, ?) order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$userId, Enums\ProjectStatusType::InProgress, Enums\ProjectStatusType::Stalled], Project::class);
+		return Db::MultiTableSelect('SELECT * from Projects inner join Ebooks on Projects.EbookId = Ebooks.EbookId where ReviewerUserId = ? and Status in (?, ?) order by regexp_replace(Title, \'^(A|An|The)\\\s\', \'\') asc', [$userId, Enums\ProjectStatusType::InProgress, Enums\ProjectStatusType::Stalled], Project::class);
 	}
 
 	/**
@@ -686,7 +686,6 @@ final class Project{
 		$object = Project::FromRow($row['Projects']);
 
 		if($row['Projects']->EbookId !== null){
-			$row['Ebooks']->EbookId = $object->EbookId;
 			$object->Ebook = Ebook::FromRow($row['Ebooks']);
 		}
 


### PR DESCRIPTION
Instead of `USING(EbookId)`, it would be easier to handle `MultiTableSelect` queries in `FromMultiTableRow()` if the queries used:  

```      
ON Projects.EbookId = Ebooks.EbookId
```
   
This is because `USING` will return only one `EbookId` column, but `ON` will return all columns from both tables. See [this passage of the manual](https://dev.mysql.com/doc/refman/8.0/en/join.html#:~:text=The%20USING%20join%20selects%20the%20coalesced%20value%20of%20corresponding%20columns%2C%20whereas%20the%20ON%20join%20selects%20all%20columns%20from%20all%20tables.) for details.

This removes the need to do:

```
$row['Ebooks']->EbookId = $object->EbookId;
```

in `FromMultiTableRow()` functions, which can be error prone.

No matter if the queries are written with `USING` or `ON`, it's worth adding an index to make the join more efficient, so this PR adds that, too. Here's how to add it to existing DBs:

```
ALTER TABLE `Projects` ADD INDEX `index1` (`EbookId`);
```