### PR TITLE
Match `Contributor` `UrlName` to `Identifier`

### DIFF
--- a/lib/Contributor.php
+++ b/lib/Contributor.php
@@ -83,14 +83,19 @@ class Contributor{
 				// Sometimes placeholders may have `'` in the name.
 				$this->Name = str_replace('\'', '’', $this->Name);
 			}
-
-			$this->UrlName = Formatter::MakeUrlSafe($this->Name);
 		}
 		else{
 			$error->Add(new Exceptions\ContributorNameRequiredException());
 		}
 
-		if(!isset($this->UrlName)){
+		if(isset($this->UrlName)){
+			$this->UrlName = trim($this->UrlName);
+
+			if($this->UrlName == ''){
+				$error->Add(new Exceptions\ContributorUrlNameRequiredException());
+			}
+		}
+		else{
 			$error->Add(new Exceptions\ContributorUrlNameRequiredException());
 		}
 


### PR DESCRIPTION
I know you fixed this once in the production DB manually, but it's currently returning a 404:

https://standardebooks.org/ebooks/samuel-butler-1612-1680 

After this change, you can fix it by re-running `scripts/deploy-ebook-to-www`:

```
/standardebooks.org/web/scripts/deploy-ebook-to-www --verbose --no-build --no-images --no-recompose --no-epubcheck --no-feeds --no-bulk-downloads /standardebooks.org/ebooks/samuel-butler-1612-1680_hudibras.git 
```

`samuel-butler-1612-1680` was the only example I could find with a special suffix so far, but I added some other cases to be careful of in the docstring.

Fixes \#459