### PR TITLE
Search artwork by `UrlName`

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -1069,6 +1069,7 @@ class Artwork{
 			$params[] = $tokenizedQuery; // art.Name
 			$params[] = $tokenizedQuery; // art.EbookUrl
 			$params[] = $tokenizedQuery; // a.Name
+			$params[] = $tokenizedQuery; // a.UrlName
 			$params[] = $tokenizedQuery; // aan.Name
 			$params[] = $tokenizedQuery; // t.Name
 
@@ -1089,6 +1090,7 @@ class Artwork{
 				            and (art.Name regexp ?
 				            or replace(art.EbookUrl, "_", " ") regexp ?
 				            or a.Name regexp ?
+				            or a.UrlName regexp ?
 				            or aan.Name regexp ?
 				            or t.Name regexp ?)
 				    group by art.ArtworkId) x', $params);
@@ -1107,6 +1109,7 @@ class Artwork{
 				  and (art.Name regexp ?
 				  or replace(art.EbookUrl, "_", " ") regexp ?
 				  or a.Name regexp ?
+				  or a.UrlName regexp ?
 				  or aan.Name regexp ?
 				  or t.Name regexp ?)
 				group by art.ArtworkId

--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -1029,9 +1029,15 @@ class Artwork{
 			$orderBy = 'art.CompletedYear desc';
 		}
 
-		// Remove diacritics and non-alphanumeric characters, but preserve apostrophes.
+		// Remove diacritics and non-alphanumeric characters.
 		if($query !== null && $query != ''){
-			$query = trim(preg_replace('|[^a-zA-Z0-9\'’ ]|ius', ' ', Formatter::RemoveDiacritics($query)));
+			$query = Formatter::RemoveDiacritics($query);
+
+			// Remove apostrophes outright, don't replace with a space.
+			$query = preg_replace('/[\'’]/u', '', $query);
+
+			// Replace all other non-alphanumeric characters with a space.
+			$query = trim(preg_replace('|[^a-zA-Z0-9 ]|ius', ' ', $query));
 		}
 		else{
 			$query = '';
@@ -1067,6 +1073,7 @@ class Artwork{
 			$tokenizedQuery = '\b(' . implode('|', $tokenArray) . ')\b';
 
 			$params[] = $tokenizedQuery; // art.Name
+			$params[] = $tokenizedQuery; // art.UrlName
 			$params[] = $tokenizedQuery; // art.EbookUrl
 			$params[] = $tokenizedQuery; // a.Name
 			$params[] = $tokenizedQuery; // a.UrlName
@@ -1088,6 +1095,7 @@ class Artwork{
 				    where
 				        ' . $statusCondition . '
 				            and (art.Name regexp ?
+				            or art.UrlName regexp ?
 				            or replace(art.EbookUrl, "_", " ") regexp ?
 				            or a.Name regexp ?
 				            or a.UrlName regexp ?
@@ -1107,6 +1115,7 @@ class Artwork{
 				  left join Tags t using (TagId)
 				where ' . $statusCondition . '
 				  and (art.Name regexp ?
+				  or art.UrlName regexp ?
 				  or replace(art.EbookUrl, "_", " ") regexp ?
 				  or a.Name regexp ?
 				  or a.UrlName regexp ?


### PR DESCRIPTION
`Artwork::GetAllByFilter()` is already removing diacritics from search terms, and `UrlName` stores the artist's name with diacritics removed by calling `Formatter::MakeUrlSafe()`.

Keeping the search by `Name` because `Formatter::MakeUrlSafe()` makes other changes to the name, too.

Fixes #461

Notes:

Searching for these terms now work:

`Körner`
`Korner`

When thinking about other edge cases and looking at  `Formatter::MakeUrlSafe()` and  `Formatter::RemoveDiacritics()`, I noticed that searching for:

`O’Keeffe`

doesn't work: https://standardebooks.org/artworks?query=O%E2%80%99Keeffe

After this PR, at least this will work:

`okeeffe`

which isn't great, but it's better.

The problem with `O’Keeffe` is that this line is turning it into `o'keeffe`

https://github.com/standardebooks/web/blob/db8d4221338669e3d47449c44733c83e42520056/lib/Artwork.php#L1032-L1034

As the comment says, it preserves apostrophes, but `Formatter::RemoveDiacritics()` is changing the apostrophe to `'` before `preg_replace()` is called. We don't have `o'keeffe` stored in the DB anywhere, just `O’Keeffe` and `okeeffe`. I don't think it's worth it do add another `replace()` to the MySQL query, so I'm going to leave it for now. We could consider an `IndexableText` field like we have for `Ebooks`. 
