### PR TITLE
Dashes

### DIFF
--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -344,7 +344,7 @@ do
 			sed --in-place --regexp-extended 's/xml:lang="([^"]+?)"/xml:lang="\1" lang="\1"/g' "${filename}"
 
 			# Add the work title to `<title>` elements in the source text.
-			sed --in-place --regexp-extended "s|<title>|<title>${workTitle} - |g" "${filename}"
+			sed --in-place --regexp-extended "s|<title>|<title>${workTitle} – |g" "${filename}"
 
 			# Wrap book contents in a `<main>` element.
 			sed --in-place --regexp-extended "s|<body([^>]*)>|<body><main\1>|; s|</body>|</main></body>|" "${filename}"

--- a/scripts/generate-feeds
+++ b/scripts/generate-feeds
@@ -194,26 +194,26 @@ SaveFeed($newestFeed, $force, null, null, NOW);
 // Create RSS/Atom feeds.
 
 // Create the RSS All feed.
-$allRssFeed = new RssFeed('Standard Ebooks - All Ebooks', 'All Standard Ebooks, most-recently-released first.', '/feeds/rss/all',  $webRoot . '/feeds/rss/all.xml', $allEbooks);
+$allRssFeed = new RssFeed('Standard Ebooks – All Ebooks', 'All Standard Ebooks, most-recently-released first.', '/feeds/rss/all',  $webRoot . '/feeds/rss/all.xml', $allEbooks);
 SaveFeed($allRssFeed, $force, null, null);
 
 // Create the RSS Newest feed.
-$newestRssFeed = new RssFeed('Standard Ebooks - Newest Ebooks', 'The ' . number_format($ebooksPerNewestEbooksFeed) . ' latest Standard Ebooks, most-recently-released first.', '/feeds/rss/new-releases', $webRoot . '/feeds/rss/new-releases.xml', $newestEbooks);
+$newestRssFeed = new RssFeed('Standard Ebooks – Newest Ebooks', 'The ' . number_format($ebooksPerNewestEbooksFeed) . ' latest Standard Ebooks, most-recently-released first.', '/feeds/rss/new-releases', $webRoot . '/feeds/rss/new-releases.xml', $newestEbooks);
 SaveFeed($newestRssFeed, $force, null, null);
 
 // Create the Atom All feed.
-$allAtomFeed = new AtomFeed('Standard Ebooks - All Ebooks', 'All Standard Ebooks, most-recently-released first.', '/feeds/atom/all',  $webRoot . '/feeds/atom/all.xml', $allEbooks);
+$allAtomFeed = new AtomFeed('Standard Ebooks – All Ebooks', 'All Standard Ebooks, most-recently-released first.', '/feeds/atom/all',  $webRoot . '/feeds/atom/all.xml', $allEbooks);
 SaveFeed($allAtomFeed, $force, null, null, NOW);
 
 // Create the Atom Newest feed.
-$newestAtomFeed = new AtomFeed('Standard Ebooks - Newest Ebooks', 'The ' . number_format($ebooksPerNewestEbooksFeed) . ' latest Standard Ebooks, most-recently-released first.', '/feeds/atom/new-releases', $webRoot . '/feeds/atom/new-releases.xml', $newestEbooks);
+$newestAtomFeed = new AtomFeed('Standard Ebooks – Newest Ebooks', 'The ' . number_format($ebooksPerNewestEbooksFeed) . ' latest Standard Ebooks, most-recently-released first.', '/feeds/atom/new-releases', $webRoot . '/feeds/atom/new-releases.xml', $newestEbooks);
 SaveFeed($newestAtomFeed, $force, null, null, NOW);
 
 // Generate each individual subject feed.
 foreach($ebooksBySubject as $subject => $ebooks){
 	usort($ebooks, 'SortByUpdatedDesc');
 
-	$title = 'Standard Ebooks - ' . $subjects[$subject]['name'] . ' Ebooks';
+	$title = 'Standard Ebooks – ' . $subjects[$subject]['name'] . ' Ebooks';
 	$subtitle = 'Standard Ebooks in the “' . strtolower($subjects[$subject]['name']) . '” subject, most-recently-released first.';
 
 	$subjectRssFeed = new RssFeed($title, $subtitle, '/feeds/rss/subjects/' . Formatter::MakeUrlSafe($subject),  $webRoot . '/feeds/rss/subjects/' . Formatter::MakeUrlSafe($subject) . '.xml', $ebooks);
@@ -229,7 +229,7 @@ foreach($ebooksByCollection as $collection => $ebooks){
 
 	$titleName = preg_replace('/^The /ius', '', $collections[$collection]['name']);
 
-	$title ='Standard Ebooks - Ebooks in the ' . $titleName . ' collection';
+	$title ='Standard Ebooks – Ebooks in the ' . $titleName . ' collection';
 	$subtitle = 'Standard Ebooks in the ' . $titleName . ' collection, most-recently-released first.';
 
 	$collectionRssFeed = new RssFeed($title, $subtitle, '/feeds/rss/collections/' . Formatter::MakeUrlSafe($collection),  $webRoot . '/feeds/rss/collections/' . Formatter::MakeUrlSafe($collection) . '.xml', $ebooks);
@@ -243,7 +243,7 @@ foreach($ebooksByCollection as $collection => $ebooks){
 foreach($ebooksByAuthor as $collection => $ebooks){
 	usort($ebooks, 'SortByUpdatedDesc');
 
-	$title = 'Standard Ebooks - Ebooks by ' . $authors[$collection]['name'];
+	$title = 'Standard Ebooks – Ebooks by ' . $authors[$collection]['name'];
 	$subtitle = 'Standard Ebooks by ' . $authors[$collection]['name'] . ', most-recently-released first.';
 
 	$collectionRssFeed = new RssFeed($title, $subtitle, '/feeds/rss/authors/' . $authors[$collection]['id'],  $webRoot . '/feeds/rss/authors/' . $authors[$collection]['id'] . '.xml', $ebooks);

--- a/templates/Header.php
+++ b/templates/Header.php
@@ -33,7 +33,7 @@ if(!$isXslt){
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head prefix="twitter: https://twitter.com/ schema: http://schema.org/"><? /* The `og` RDFa prefix is part of the RDFa spec */ ?>
 	<meta charset="utf-8"/>
-	<title><? if($title != ''){ ?><?= Formatter::EscapeHtml($title) ?> - <? } ?>Standard Ebooks: Free and liberated ebooks, carefully produced for the true book lover</title>
+	<title><? if($title != ''){ ?><?= Formatter::EscapeHtml($title) ?> – <? } ?>Standard Ebooks: Free and liberated ebooks, carefully produced for the true book lover</title>
 	<? if($description != ''){ ?>
 		<meta content="<?= Formatter::EscapeHtml($description) ?>" name="description"/>
 	<? } ?>
@@ -70,9 +70,9 @@ if(!$isXslt){
 	<link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
 	<link href="/manifest.json" rel="manifest"/>
 	<? if($feedUrl === null){ ?>
-		<link rel="alternate" type="application/atom+xml" title="Standard Ebooks - New Releases" href="https://standardebooks.org/feeds/atom/new-releases"/>
-		<link rel="alternate" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Standard Ebooks - New Releases" href="https://standardebooks.org/feeds/opds/new-releases"/>
-		<link rel="alternate" type="application/rss+xml" title="Standard Ebooks - New Releases" href="https://standardebooks.org/feeds/rss/new-releases"/>
+		<link rel="alternate" type="application/atom+xml" title="Standard Ebooks – New Releases" href="https://standardebooks.org/feeds/atom/new-releases"/>
+		<link rel="alternate" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Standard Ebooks – New Releases" href="https://standardebooks.org/feeds/opds/new-releases"/>
+		<link rel="alternate" type="application/rss+xml" title="Standard Ebooks – New Releases" href="https://standardebooks.org/feeds/rss/new-releases"/>
 	<? }else{ ?>
 		<link rel="alternate" type="application/atom+xml" title="<?= Formatter::EscapeHtml($feedTitle) ?>" href="/feeds/atom<?= Formatter::EscapeHtml($feedUrl) ?>"/>
 		<link rel="alternate" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="<?= Formatter::EscapeHtml($feedTitle) ?>" href="/feeds/opds<?= Formatter::EscapeHtml($feedUrl) ?>"/>

--- a/www/authors/get.php
+++ b/www/authors/get.php
@@ -31,7 +31,7 @@ try{
 catch(Exceptions\AuthorNotFoundException){
 	Template::ExitWithCode(Enums\HttpCode::NotFound);
 }
-?><?= Template::Header(['title' => 'Ebooks by ' . $author, 'feedUrl' => str_replace('/ebooks/', '/authors/', $authorUrl), 'feedTitle' => 'Standard Ebooks - Ebooks by ' . $author, 'highlight' => 'ebooks', 'description' => 'All of the Standard Ebooks ebooks by ' . $author, 'canonicalUrl' => SITE_URL . $authorUrl]) ?>
+?><?= Template::Header(['title' => 'Ebooks by ' . $author, 'feedUrl' => str_replace('/ebooks/', '/authors/', $authorUrl), 'feedTitle' => 'Standard Ebooks – Ebooks by ' . $author, 'highlight' => 'ebooks', 'description' => 'All of the Standard Ebooks ebooks by ' . $author, 'canonicalUrl' => SITE_URL . $authorUrl]) ?>
 <main class="ebooks">
 	<h1 class="is-collection">Ebooks by <?= $ebooks[0]->AuthorsHtml ?></h1>
 	<? if($showLinks){ ?>

--- a/www/blog/public-domain-day-2025.php
+++ b/www/blog/public-domain-day-2025.php
@@ -100,7 +100,7 @@ foreach($ebooks as $ebook){
 
 ksort($ebooksWithDescriptions);
 
-?><?= Template::Header(['title' => 'Public Domain Day 2025 in Literature - Blog', 'highlight' => '', 'description' => 'Read about the new ebooks Standard Ebooks is releasing for Public Domain Day 2025!', 'css' => ['/css/public-domain-day.css']]) ?>
+?><?= Template::Header(['title' => 'Public Domain Day 2025 in Literature – Blog', 'highlight' => '', 'description' => 'Read about the new ebooks Standard Ebooks is releasing for Public Domain Day 2025!', 'css' => ['/css/public-domain-day.css']]) ?>
 <main>
 	<section class="narrow blog has-hero">
 		<nav class="breadcrumbs"><a href="/blog">Blog</a> →</nav>

--- a/www/collections/get.php
+++ b/www/collections/get.php
@@ -11,7 +11,7 @@ try{
 	$pageHeader = 'Free Ebooks in the ' . Formatter::EscapeHtml($collectionName) . ' ' . ucfirst($collectionType);
 
 	$feedUrl = '/collections/' . $collection->UrlName;
-	$feedTitle = 'Standard Ebooks - Ebooks in the ' . Formatter::EscapeHtml($collectionName) . ' ' . $collectionType;
+	$feedTitle = 'Standard Ebooks – Ebooks in the ' . Formatter::EscapeHtml($collectionName) . ' ' . $collectionType;
 }
 catch(Exceptions\CollectionNotFoundException){
 	Template::ExitWithCode(Enums\HttpCode::NotFound);

--- a/www/contribute/how-tos/how-to-choose-and-create-a-cover-image.php
+++ b/www/contribute/how-tos/how-to-choose-and-create-a-cover-image.php
@@ -263,7 +263,7 @@
 									<dt><a href="https://collections.britishart.yale.edu/?utf8=%E2%9C%93&amp;f%5Bcollection_ss%5D%5B%5D=Paintings+and+Sculpture&amp;range%5BearliestDate_is%5D%5Bbegin%5D=1614&amp;range%5BearliestDate_is%5D%5Bend%5D=1900&amp;search_field=all_fields&amp;q=">Yale Center for British Art</a></dt>
 									<dd>CC0 items have a “0 Public Domain” icon under the picture, which links to the CC0 license.</dd>
 									<dt><a href="https://artgallery.yale.edu/">Yale University Art Gallery</a></dt>
-									<dd>CC0 items say “No Copyright - United States” under the “Object copyright” section, which links to a CC0 license.</dd>
+									<dd>CC0 items say “No Copyright – United States” under the “Object copyright” section, which links to a CC0 license.</dd>
 									<dt><a href="https://www.artic.edu/collection?q=test&amp;is_public_domain=1&amp;department_ids=European+Painting+and+Sculpture">Art Institute of Chicago</a></dt>
 									<dd>CC0 items say CC0 in the lower left of the painting in the art detail page.</dd>
 									<dt><a href="https://art.thewalters.org/">The Walters Art Museum</a></dt>
@@ -303,7 +303,7 @@
 									<dt><a href="https://digitaltmuseum.no/search/?aq=owner%3F%3A%22LKM%22+license%3F%3A%22zero%22+type%3F%3A%22Fineart%22+media%3F%3A%22image%22">Lillehammer Kunstmuseum</a></dt>
 									<dd>CC0 items say “License: CC CC0 1.0” under the “License information” section. In the art metadata, “Owner of collection” <strong>must</strong> be “Lillehammer Kunstmuseum.” Any other art on <a href="https://www.digitaltmuseum.no">digitaltmuseum.no</a> or <a href="https://www.digitaltmuseum.se">digitaltmuseum.se</a> must be cleared separately.</dd>
 									<dt><a href="https://zbiory.mnk.pl/">National Museum in Krakow</a></dt>
-									<dd>CC0 items say "CC0 - Public Domain" under the Copyright section.</dd>
+									<dd>CC0 items say "CC0 – Public Domain" under the Copyright section.</dd>
 									<dt><a href="https://www.nationalmuseum.se/en/explore-art-and-design/images/free-images">National Museum in Stockholm</a></dt>
 									<dd>CC-PD items have the CC-PD mark in the lower left of the item’s detail view.</dd>
 									<dt><a href="https://dams.birminghammuseums.org.uk/asset-bank/action/viewDefaultHome">Birmingham Museums</a></dt>
@@ -311,7 +311,7 @@
 									<dt><a href="https://collections.brightonmuseums.org.uk/?q=&amp;departments=Fine%20Art">Brighton &amp; Hove Museums</a></dt>
 									<dd>CC0 items have the URL of the CC0 license in the “License” field.</dd>
 									<dt><a href="https://emuseum.aberdeencity.gov.uk/collections/102307/open-access-images--fine-art">Aberdeen Archives, Gallery &amp; Museums</a></dt>
-									<dd>CC0 items say “Out of copyright - CC0” on the copyright line.</dd>
+									<dd>CC0 items say “Out of copyright – CC0” on the copyright line.</dd>
 								</dl>
 							</section>
 						</li>

--- a/www/contribute/uncategorized-art-resources.php
+++ b/www/contribute/uncategorized-art-resources.php
@@ -17,7 +17,7 @@
 			<li><p><a href="https://catalog.hathitrust.org/Record/009438136">Catalog Record: Illustrated catalogue : paintings in the...</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=Qn1FAQAAMAAJ">A.L.A. Portrait Index: Index to Portraits Contained in Printed Books and</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=njp.32101066379189;view=thumb;seq=5">The Nicolas Roerich exhibition, with introduction and catalogue</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=NBgtAAAAYAAJ">Art of the British Empire Overseas - Charles Holme</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=NBgtAAAAYAAJ">Art of the British Empire Overseas – Charles Holme</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=i6hEAQAAMAAJ">The International Studio</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/008018731">Catalog Record: Royal Academy pictures and sculpture</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/100237187">Catalog Record: Paris-Salon, 1883</a></p></li>
@@ -34,13 +34,13 @@
 			<li><p><a href="http://brandywine.doetech.net/Detlobjps.cfm?ParentListID=126891&amp;amp;ObjectID=1531590&amp;amp;rec_num=175">Object Detail</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=yale.39002088545273;view=thumb;seq=57">(this is a whole series) Royal Academy pictures and sculpture. 1900</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/011254573">Catalog Record: The art of the Hon. John Collier</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=_0w4AAAAMAAJ">The Story of American Painting: The Evolution of Painting in America from - Charles Henry Caffin</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=_0w4AAAAMAAJ">The Story of American Painting: The Evolution of Painting in America from – Charles Henry Caffin</a></p></li>
 			<li><p><a href="https://archive.org/details/diekunstmonatshe21mnuoft">Die Kunst : Monatsheft für freie und angewandte Kunst</a></p></li>
 			<li><p><a href="https://archive.org/stream/cubistesfuturist00coquuoft#page/267/mode/thumb">Cubistes, futuristes, passéistes; essai sur la</a></p></li>
 			<li><p><a href="https://archive.org/stream/einblickin00wald#page/23/mode/thumb">Einblick in Kunst: Expressionismus, Futurismus,...</a></p></li>
 			<li><p><a href="https://archive.org/stream/studiointernatio54lond#page/8/mode/thumb">Studio international</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=q7GUsAXiiA4C">The Magazine of Art</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=sdJAAAAAYAAJ">Cubists and Post-impressionism - Arthur Jerome Eddy</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=sdJAAAAAYAAJ">Cubists and Post-impressionism – Arthur Jerome Eddy</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/100344340">Catalog Record: L'art flamand</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/100445834">Catalog Record: L'école belge de peinture, 1830-1905</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/100578657">Catalog Record: Fernand Khnopff</a></p></li>
@@ -48,23 +48,23 @@
 			<li><p><a href="https://archive.org/stream/catalogueofficiel00expo#page/40/mode/thumb">Catalogue officiel illustré de l'Exposition cen...</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=njp.32101067654994;view=1up;seq=6">Offizieller Katalog der Internationalen Kunst-Ausstellung (1899).</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=wu.89057259921;view=1up;seq=23">British painting, by Irene Maguinness.</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=Jl9OAQAAMAAJ">Illustrated Catalogue: Paintings in the Metropolitan Museum of Art, New York - George Henry Story</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=Jl9OAQAAMAAJ">Illustrated Catalogue: Paintings in the Metropolitan Museum of Art, New York – George Henry Story</a></p></li>
 			<li><p><a href="https://archive.org/stream/bub_gb_yxRaAAAAYAAJ#page/n54/mode/thumb">Impressionisten Guys, Manet, Van Gogh, Pissarro...</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/000636935">Catalog Record: The Royal Academy illustrated</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/000071454">Catalog Record: The Art journal</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/100585480">Catalog Record: Handbuch der Kunstgeschichte</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=nyp.33433082172564;view=thumb;seq=9">Catalogue of the annual exhibition. v. 70-71 (1901-1902).</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/000521207">Catalog Record: Catalogue of the annual exhibition of...</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=mEpGAQAAIAAJ">Meissonier, his life and his art - Jean Louis Ernest Meissonier, Octave Gréard</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=mEpGAQAAIAAJ">Meissonier, his life and his art – Jean Louis Ernest Meissonier, Octave Gréard</a></p></li>
 			<li><p><a href="https://babel.hathitrust.org/cgi/pt?id=gri.ark:/13960/t4fn6k42j;view=thumb;seq=41">Catalogue of the annual exhibition / The Pennsylvania 1905.</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=xCtAAAAAYAAJ">Zur Geschichte der Düsseldorfer Kunst insbesondere im xix. Jahrhundert - Friedrich Schaarschmidt</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=v7hHAQAAIAAJ">Bryan's dictionary of painters and engravers - Michael Bryan, George Charles Williamson</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=xCtAAAAAYAAJ">Zur Geschichte der Düsseldorfer Kunst insbesondere im xix. Jahrhundert – Friedrich Schaarschmidt</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=v7hHAQAAIAAJ">Bryan's dictionary of painters and engravers – Michael Bryan, George Charles Williamson</a></p></li>
 			<li><p><a href="https://archive.org/details/memorialexhibiti00eaki">Memorial exhibition of the works of the late Thomas Eakins, beginning December 23, 1917 and continuing through January 13, 1918: Eakins, Thomas, 1844-1916</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=CSFbAAAAYAAJ">Kunst und Künstler: Illustrierte Monatsschrift für bildende Kunst und - Karl Scheffler</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=CSFbAAAAYAAJ">Kunst und Künstler: Illustrierte Monatsschrift für bildende Kunst und – Karl Scheffler</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/000415396">Catalog Record: Gauguin et le groupe de Pont-Aven. Documents...</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/000062223">Catalog Record: Salon of the Nationale</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=JAcrAAAAYAAJ">Academy Notes</a></p></li>
-			<li><p><a href="https://books.google.com/books?id=etcwAQAAMAAJ">Great Painters of the XLX Century and Their Paintings - Léonce Bénédite</a></p></li>
+			<li><p><a href="https://books.google.com/books?id=etcwAQAAMAAJ">Great Painters of the XLX Century and Their Paintings – Léonce Bénédite</a></p></li>
 			<li><p><a href="https://catalog.hathitrust.org/Record/005722615">Catalog Record: Catalogue of paintings and drawings</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=nH9HAQAAMAAJ">The International Studio</a></p></li>
 			<li><p><a href="https://books.google.com/books?id=B6saAAAAYAAJ">Exhibition: Oil Paintings by Contemporary American Artists</a></p></li>

--- a/www/ebooks/get.php
+++ b/www/ebooks/get.php
@@ -71,7 +71,7 @@ catch(Exceptions\EbookNotFoundException){
 
 	Template::ExitWithCode(Enums\HttpCode::NotFound);
 }
-?><?= Template::Header(['title' => strip_tags($ebook->TitleWithCreditsHtml) . ' - Free ebook download', 'ogType' => 'book', 'coverUrl' => $ebook->DistCoverUrl, 'highlight' => 'ebooks', 'description' => 'Free epub ebook download of the Standard Ebooks edition of ' . $ebook->Title . ': ' . $ebook->Description, 'canonicalUrl' => SITE_URL . $ebook->Url]) ?>
+?><?= Template::Header(['title' => strip_tags($ebook->TitleWithCreditsHtml) . ' – Free ebook download', 'ogType' => 'book', 'coverUrl' => $ebook->DistCoverUrl, 'highlight' => 'ebooks', 'description' => 'Free epub ebook download of the Standard Ebooks edition of ' . $ebook->Title . ': ' . $ebook->Description, 'canonicalUrl' => SITE_URL . $ebook->Url]) ?>
 <main>
 	<article class="ebook" typeof="schema:Book" about="<?= $ebook->Url ?>">
 		<meta property="schema:description" content="<?= Formatter::EscapeHtml($ebook->Description) ?>"/>

--- a/www/feeds/atom/style.php
+++ b/www/feeds/atom/style.php
@@ -18,8 +18,8 @@ print("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
 	<?= Template::Header(['isXslt' => true]) ?>
 	<main class="opds">
 		<xsl:choose>
-			<xsl:when test="contains(/atom:feed/atom:title, 'Standard Ebooks - ')">
-				<h1><xsl:value-of select="substring-after(/atom:feed/atom:title, 'Standard Ebooks - ')"/></h1>
+			<xsl:when test="contains(/atom:feed/atom:title, 'Standard Ebooks – ')">
+				<h1><xsl:value-of select="substring-after(/atom:feed/atom:title, 'Standard Ebooks – ')"/></h1>
 			</xsl:when>
 			<xsl:otherwise>
 				<h1><xsl:value-of select="/atom:feed/atom:title"/></h1>

--- a/www/feeds/get.php
+++ b/www/feeds/get.php
@@ -41,13 +41,13 @@ try{
 	if($collectionType == Enums\FeedCollectionType::Authors){
 		$title = 'Ebook feeds for ' . $label;
 		$description = 'A list of available ebook feeds for ebooks by ' . $label . '.';
-		$feedTitle = 'Standard Ebooks - Ebooks by ' . $label;
+		$feedTitle = 'Standard Ebooks – Ebooks by ' . $label;
 	}
 
 	if($collectionType == Enums\FeedCollectionType::Collections){
 		$title = 'Ebook feeds for the ' . $label . ' collection';
 		$description = 'A list of available ebook feeds for ebooks in the ' . $label . ' collection.';
-		$feedTitle = 'Standard Ebooks - Ebooks in the ' . $label . ' collection';
+		$feedTitle = 'Standard Ebooks – Ebooks in the ' . $label . ' collection';
 	}
 
 	$feedUrl = '/' . $collectionType->value . '/' . $target;

--- a/www/feeds/opds/style.php
+++ b/www/feeds/opds/style.php
@@ -18,8 +18,8 @@ print("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
 	<?= Template::Header(['isXslt' => true]) ?>
 	<main class="opds">
 		<xsl:choose>
-			<xsl:when test="contains(/atom:feed/atom:title, 'Standard Ebooks - ')">
-				<h1><xsl:value-of select="substring-after(/atom:feed/atom:title, 'Standard Ebooks - ')"/></h1>
+			<xsl:when test="contains(/atom:feed/atom:title, 'Standard Ebooks – ')">
+				<h1><xsl:value-of select="substring-after(/atom:feed/atom:title, 'Standard Ebooks – ')"/></h1>
 			</xsl:when>
 			<xsl:otherwise>
 				<h1><xsl:value-of select="/atom:feed/atom:title"/></h1>

--- a/www/feeds/rss/style.php
+++ b/www/feeds/rss/style.php
@@ -18,8 +18,8 @@ print("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
 	<?= Template::Header(['isXslt' => true]) ?>
 	<main class="opds">
 		<xsl:choose>
-			<xsl:when test="contains(/rss/channel/title, 'Standard Ebooks - ')">
-				<h1><xsl:value-of select="substring-after(/rss/channel/title, 'Standard Ebooks - ')"/></h1>
+			<xsl:when test="contains(/rss/channel/title, 'Standard Ebooks – ')">
+				<h1><xsl:value-of select="substring-after(/rss/channel/title, 'Standard Ebooks – ')"/></h1>
 			</xsl:when>
 			<xsl:otherwise>
 				<h1><xsl:value-of select="/rss/channel/title"/></h1>


### PR DESCRIPTION
Several places use hyphens when they should use dashes. This is particularly noticeable in the “Read Online” books where they show up in the page body, not just the title.

Several XSL tests rely on this, which is why I changed all instances instead of just the obvious ones. Thus, the change needs to be reviewed carefully. Unfortunately I’m unable to test a local deploy at present.