### PR TITLE
Make bold/strong regular expression catch more cases

### DIFF
--- a/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
+++ b/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
@@ -102,7 +102,7 @@
 			<li>
 				<h2>Review bold and strong elements</h2>
 				<p>The <code class="html"><span class="p">&lt;</span><span class="nt">b</span><span class="p">&gt;</span></code> and <code><span class="p">&lt;</span><span class="nt">strong</span><span class="p">&gt;</span></code> elements are not to be used interchangeably (see relevant section of the Manual <a href="manual/latest/single-page#8.3.3">here</a>). Use the following command to check their usage in the production (alternatively, use the regular expression search function in a text editor):</p>
-				<code class="terminal"><b>grep</b> --recursive --line-number --extended-regexp <i>"&lt;(b|strong)&gt;"</i> <u>src/epub/text/<i class="glob">*</i>.xhtml</u></code>
+				<code class="terminal"><b>grep</b> --recursive --line-number --extended-regexp <i>"&lt;(b\W|strong)"</i> <u>src/epub/text/<i class="glob">*</i>.xhtml</u></code>
 			</li>
 			<li>
 				<h2>Review XHTML file structure</h2>


### PR DESCRIPTION
This regex is a little narrower than I'd like, because it can't catch elements with semantics. This revised regex will find elements with semantics too, while filtering out things like blockquotes with the use of the non-word character class.