### PR TITLE
Add default values for config vars

### DIFF
--- a/config/php/fpm/standardebooks.test.ini
+++ b/config/php/fpm/standardebooks.test.ini
@@ -18,3 +18,9 @@ opcache.validate_timestamps = Off
 
 [app]
 app.site_status = "dev"
+
+[se]
+se.secrets.email.admin_address = "admin@example.com"
+se.secrets.email.editor_in_chief_address = "editor@example.com"
+se.secrets.email.no_reply_address = "noreply@example.com"
+se.secrets.postmark.username = "smtp_username"


### PR DESCRIPTION
After 9d1b66d19e30bc5b258b2c3a8978bd5f17f1dbc0, running PHPStan fails if any config vars are not set with a hard-to-understand error message:

```
$ ./vendor/bin/phpstan analyse -c ./config/phpstan/phpstan.neon
PHP Fatal error:  Uncaught Safe\Exceptions\InfoException: An error occurred in /standardebooks.org/web/vendor/thecodingmachine/safe/generated/Exceptions/InfoException.php:9
Stack trace:
#0 /standardebooks.org/web/vendor/thecodingmachine/safe/generated/8.3/info.php(228): Safe\Exceptions\InfoException::createFromPhpError()
#1 /standardebooks.org/web/lib/Constants.php(72): Safe\get_cfg_var()
#2 /standardebooks.org/web/vendor/composer/autoload_real.php(41): require('...')
#3 /standardebooks.org/web/vendor/composer/autoload_real.php(45): {closure}()
#4 /standardebooks.org/web/vendor/autoload.php(25): ComposerAutoloaderInitb0f9117ed0fa1c3563107eca1d2a77b9::getLoader()
#5 phar:///standardebooks.org/web/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(55): require_once('...')
#6 phar:///standardebooks.org/web/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(115): _PHPStan_24e2736d6\{closure}()
#7 /standardebooks.org/web/vendor/phpstan/phpstan/phpstan(8): require('...')
#8 /standardebooks.org/web/vendor/bin/phpstan(119): include('...')
#9 {main}
  thrown in /standardebooks.org/web/vendor/thecodingmachine/safe/generated/Exceptions/InfoException.php on line 9
```

I'm up for changing the section or the dummy values I put in for these config vars.

(Potential feedback for PHPStan, but maybe I'm just missing something: It's a little harsh that `phpstan` basically doesn't start and doesn't print the config var that's missing, even for other commands like `./vendor/bin/phpstan clear-result-cache`.)