### PR TITLE
 Replace `EbookUrl` with `EbookId` in `Artworks`

### DIFF
--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS `Artworks` (
   `CopyrightPageUrl` varchar(255) NULL,
   `ArtworkPageUrl` varchar(255) NULL,
   `IsPublishedInUs` tinyint(1) NOT NULL DEFAULT FALSE,
-  `EbookUrl` varchar(255) NULL,
+  `EbookId` int(10) unsigned NULL,
   `MimeType` enum('image/jpeg', 'image/png', 'image/bmp', 'image/tiff') NOT NULL,
   `Exception` TEXT NULL DEFAULT NULL,
   `Notes` TEXT NULL DEFAULT NULL,

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -20,7 +20,8 @@ use function Safe\shell_exec;
  * @property array<Contributor> $Translators
  * @property array<Contributor> $Contributors
  * @property ?array<string> $TocEntries A list of non-Roman ToC entries *only if* the work has the `se:is-a-collection` metadata element; `null` otherwise.
- * @property string $Url
+ * @property string $Url The correct URL to use in order to link to this ebook. Its format is `/ebooks/...`
+ * @property string $FullUrl The absolute URL that reviewers and admins may enter into forms in order to refer to this ebook. Its format is `https://standardebooks.org/ebooks/...`
  * @property string $EditUrl
  * @property string $DeleteUrl
  * @property bool $HasDownloads
@@ -104,6 +105,7 @@ final class Ebook{
 	/** @var ?array<string> $_TocEntries */
 	protected ?array $_TocEntries = null;
 	protected string $_Url;
+	protected string $_FullUrl;
 	protected string $_EditUrl;
 	protected string $_DeleteUrl;
 	protected bool $_HasDownloads;
@@ -391,6 +393,10 @@ final class Ebook{
 
 	protected function GetUrl(): string{
 		return $this->_Url ??= str_replace(EBOOKS_IDENTIFIER_ROOT, '', $this->Identifier);
+	}
+
+	protected function GetFullUrl(): string{
+		return $this->_FullUrl ??= preg_replace('/^url:/ius', '', $this->Identifier);
 	}
 
 	protected function GetEditUrl(): string{

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -151,8 +151,8 @@ final class Ebook{
 							from
 							Artworks
 							where
-							EbookUrl = ?
-						', [preg_replace('/^url:/iu', '', $this->Identifier)], Artwork::class)[0] ?? null;
+							EbookId = ?
+						', [$this->EbookId], Artwork::class)[0] ?? null;
 	}
 
 	/**

--- a/lib/RssFeed.php
+++ b/lib/RssFeed.php
@@ -1,7 +1,6 @@
 <?
 use function Safe\file_get_contents;
 use function Safe\filesize;
-use function Safe\preg_replace;
 
 /**
  * @property array<Ebook> $Entries
@@ -50,7 +49,7 @@ class RssFeed extends Feed{
 			/** @var Ebook $entry */
 			$obj = new stdClass();
 			$obj->Size = (string)filesize(WEB_ROOT . $entry->EpubUrl);
-			$obj->Id = preg_replace('/^url:/ius', '', $entry->Identifier);
+			$obj->Id = $entry->FullUrl;
 			$currentEntries[] = $obj;
 		}
 

--- a/templates/ArtworkForm.php
+++ b/templates/ArtworkForm.php
@@ -187,7 +187,7 @@ $isEditForm ??= false;
 			<label>
 				<span>In use by</span>
 				<span>The full S.E. ebook URL. If not in use, leave this blank.</span>
-				<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" value="<?= Formatter::EscapeHtml($artwork->EbookUrl) ?>"/>
+				<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" <? if(isset($artwork->Ebook)){ ?>value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>"<? } ?>/>
 			</label>
 		<? } ?>
 	</fieldset>

--- a/templates/ArtworkList.php
+++ b/templates/ArtworkList.php
@@ -8,7 +8,7 @@
 		<?
 			$class = '';
 
-			if($artwork->EbookUrl !== null){
+			if($artwork->EbookId !== null){
 				$class .= ' in-use';
 			}
 

--- a/templates/RssEntry.php
+++ b/templates/RssEntry.php
@@ -1,6 +1,5 @@
 <?
 use function Safe\filesize;
-use function Safe\preg_replace;
 
 /**
  * @var Ebook $entry
@@ -11,7 +10,7 @@ use function Safe\preg_replace;
 	<link><?= SITE_URL . Formatter::EscapeXml($entry->Url) ?></link>
 	<description><?= Formatter::EscapeXml($entry->Description) ?></description>
 	<pubDate><?= $entry->EbookCreated?->format(Enums\DateTimeFormat::Rss->value) ?></pubDate>
-	<guid><?= Formatter::EscapeXml(preg_replace('/^url:/ius', '', $entry->Identifier)) ?></guid>
+	<guid><?= Formatter::EscapeXml($entry->FullUrl) ?></guid>
 	<? foreach($entry->Tags as $tag){ ?>
 		<category domain="https://standardebooks.org/vocab/subjects"><?= Formatter::EscapeXml($tag->Name) ?></category>
 	<? } ?>

--- a/www/artworks/get.php
+++ b/www/artworks/get.php
@@ -216,10 +216,10 @@ catch(Exceptions\InvalidPermissionsException){
 					<label>
 						<span>In use by</span>
 						<span>The full S.E. ebook URL. If not in use, leave this blank.</span>
-						<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" value="<?= Formatter::EscapeHtml($artwork->EbookUrl) ?>"/>
+						<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>"/>
 					</label>
 				<? }else{ ?>
-					<input type="hidden" name="artwork-ebook-url" value="<?= Formatter::EscapeHtml($artwork->EbookUrl) ?>" />
+					<input type="hidden" name="artwork-ebook-url" value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>" />
 				<? } ?>
 				<div class="footer">
 					<button>Save changes</button>

--- a/www/artworks/get.php
+++ b/www/artworks/get.php
@@ -124,15 +124,11 @@ catch(Exceptions\InvalidPermissionsException){
 				<td>Status:</td>
 				<td>
 					<?= ucfirst($artwork->Status->value) ?>
-					<? if($artwork->EbookUrl !== null){ ?>
+					<? if(isset($artwork->Ebook)){ ?>
 						— in use by
-						<? if($artwork->Ebook !== null && $artwork->Ebook->Url !== null){ ?>
 							<i>
 								<a href="<?= $artwork->Ebook->Url ?>"><?= Formatter::EscapeHtml($artwork->Ebook->Title) ?></a>
 							</i><? if($artwork->Ebook->IsPlaceholder()){ ?>(unreleased)<? } ?>
-						<? }else{ ?>
-							<code><?= Formatter::EscapeHtml($artwork->EbookUrl) ?></code> (unreleased)
-						<? } ?>
 					<? } ?>
 				</td>
 			</tr>
@@ -216,10 +212,10 @@ catch(Exceptions\InvalidPermissionsException){
 					<label>
 						<span>In use by</span>
 						<span>The full S.E. ebook URL. If not in use, leave this blank.</span>
-						<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>"/>
+						<input type="url" name="artwork-ebook-url" placeholder="https://standardebooks.org/ebooks/..." pattern="^https:\/\/standardebooks\.org\/ebooks/[^\/]+(\/[^\/]+)+$" <? if(isset($artwork->Ebook)){ ?>value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>"<? } ?>/>
 					</label>
 				<? }else{ ?>
-					<input type="hidden" name="artwork-ebook-url" value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>" />
+					<input type="hidden" name="artwork-ebook-url" <? if(isset($artwork->Ebook)){ ?>value="<?= Formatter::EscapeHtml($artwork->Ebook->FullUrl) ?>"<? } ?> />
 				<? } ?>
 				<div class="footer">
 					<button>Save changes</button>

--- a/www/artworks/index.php
+++ b/www/artworks/index.php
@@ -67,7 +67,7 @@ try{
 
 	if($queryEbookUrl !== null){
 		// We're being called from the `review` script, and we're only interested if the artwork exists for this URL.
-		$artworks[] = Db::Query('SELECT * from Artworks where EbookUrl = ? and Status = ? limit 1', [$queryEbookUrl, Enums\ArtworkStatusType::Approved], Artwork::class)[0] ?? throw new Exceptions\ArtworkNotFoundException();
+		$artworks[] = Db::Query('SELECT a.* from Artworks a inner join Ebooks e using (EbookId) where e.Identifier = ? and Status = ? limit 1', ['url:' . $queryEbookUrl, Enums\ArtworkStatusType::Approved], Artwork::class)[0] ?? throw new Exceptions\ArtworkNotFoundException();
 		$totalArtworkCount = 1;
 	}
 	else{


### PR DESCRIPTION
Fixes #446 

Here are the steps to update your DB:

1. Add the new `EbookId` column:

```sql
ALTER TABLE Artworks ADD COLUMN `EbookId` int(10) unsigned NULL after `EbookUrl`;
```

2. Populate the `EbookId` column:

```sql
UPDATE Artworks
SET Artworks.EbookId = (
    SELECT Ebooks.EbookId
    FROM Ebooks
    WHERE CONCAT('url:', Artworks.EbookUrl) = Ebooks.Identifier
)
WHERE Artworks.EbookUrl IS NOT NULL;
```

3. Check if there are any records with `Artworks.EbookUrl` values that don't point to published books or placeholders:

```sql
SELECT ArtworkId, Name, UrlName, EbookUrl, EbookId FROM Artworks WHERE EbookUrl IS NOT NULL AND EbookId IS NULL;
```

Fix any of those artworks, either by removing the `EbookUrl` or creating the placeholder.

4. Drop the `EbookUrl` column:

```
ALTER TABLE Artworks DROP COLUMN EbookUrl;
```
