### PR TITLE
Remove non-alphanumerics (except quotes) from search query

### DIFF
--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2333,7 +2333,7 @@ final class Ebook{
 
 		if($query !== null && $query != ''){
 			// Preserve quotes in the query so the user can enter, e.g., "war and peace" for an exact match.
-			$query = trim(preg_replace('|[^a-zA-Z0-9" ]|ius', ' ', Formatter::RemoveDiacritics($query)));
+			$query = trim(preg_replace('|[^a-zA-Z0-9" ]|ius', '', Formatter::RemoveDiacritics($query)));
 
 			$whereCondition .= ' and match(e.IndexableText, e.Title, e.IndexableAuthors, e.IndexableCollections) against(?) ';
 			$params[] = $query;

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -1706,6 +1706,7 @@ final class Ebook{
 			}
 		}
 
+		$this->IndexableText = str_replace('-', ' ', $this->IndexableText);
 		$this->IndexableText = Formatter::RemoveDiacriticsAndNonalphanumerics($this->IndexableText);
 
 		if($this->IndexableText == ''){
@@ -1719,6 +1720,7 @@ final class Ebook{
 			$this->IndexableAuthors .= ' ' . $author->Name;
 		}
 
+		$this->IndexableAuthors = str_replace('-', ' ', $this->IndexableAuthors);
 		$this->IndexableAuthors = Formatter::RemoveDiacriticsAndNonalphanumerics($this->IndexableAuthors);
 
 		// Initialize `IndexableCollections`.
@@ -1728,6 +1730,7 @@ final class Ebook{
 			$this->IndexableCollections .= ' ' . $collectionMembership->Collection->Name;
 		}
 
+		$this->IndexableCollections = str_replace('-', ' ', $this->IndexableCollections);
 		$this->IndexableCollections = Formatter::RemoveDiacriticsAndNonalphanumerics($this->IndexableCollections);
 
 		if($this->IndexableCollections == ''){
@@ -2332,6 +2335,8 @@ final class Ebook{
 		}
 
 		if($query !== null && $query != ''){
+			$query = str_replace('-', ' ', $query);
+
 			// Preserve quotes in the query so the user can enter, e.g., "war and peace" for an exact match.
 			$query = trim(preg_replace('|[^a-zA-Z0-9" ]|ius', '', Formatter::RemoveDiacritics($query)));
 


### PR DESCRIPTION
That is, don't replace non-alphanumerics with a space. This matches the behavior of Formatter::RemoveDiacriticsAndNonalphanumerics(), which would be used here except that function would also remove quotes.  We actually discussed not introducing spaces previously, but I made a mistake and didn't apply the same change to the user's search query: https://github.com/standardebooks/web/pull/470#discussion_r1929591492

This change fixes queries with compound words like:

`Haycraft-Queen`

and also fixes queries for authors with apostrophes:

`O'Neill`

No changes to existing DBs are necessary because they already have terms like `haycraftqueen` and `oneill` stored in `IndexableCollections` and `IndexableAuthors`.

Fixes #484 