### PR TITLE
Identifiers no longer prefixed with `url:`

### DIFF
--- a/lib/Artwork.php
+++ b/lib/Artwork.php
@@ -1147,7 +1147,7 @@ final class Artwork{
 		$ebookUrl = HttpInput::Str(POST, 'artwork-ebook-url');
 		if(isset($ebookUrl)){
 			try{
-				$ebook = Ebook::GetByIdentifier('url:' . $ebookUrl);
+				$ebook = Ebook::GetByIdentifier($ebookUrl);
 				$this->EbookId = $ebook->EbookId;
 			}
 			catch(Exceptions\EbookNotFoundException){

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -35,7 +35,7 @@ const MANUAL_PATH =			WEB_ROOT . '/manual';
 const EBOOKS_DIST_PATH =		WEB_ROOT . '/ebooks/';
 const COVER_ART_UPLOAD_PATH =		'/images/cover-uploads/';
 
-const EBOOKS_IDENTIFIER_ROOT =		'url:https://standardebooks.org';
+const EBOOKS_IDENTIFIER_ROOT =		'https://standardebooks.org';
 const EBOOKS_IDENTIFIER_PREFIX =	EBOOKS_IDENTIFIER_ROOT . '/ebooks/';
 
 const DATABASE_DEFAULT_DATABASE = 	'se';

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -396,7 +396,7 @@ final class Ebook{
 	}
 
 	protected function GetFullUrl(): string{
-		return $this->_FullUrl ??= preg_replace('/^url:/ius', '', $this->Identifier);
+		return $this->_FullUrl ??= $this->Identifier;
 	}
 
 	protected function GetEditUrl(): string{
@@ -412,7 +412,7 @@ final class Ebook{
 	}
 
 	protected function GetUrlSafeIdentifier(): string{
-		return $this->_UrlSafeIdentifier ??= str_replace(['url:https://standardebooks.org/ebooks/', '/'], ['', '_'], $this->Identifier);
+		return $this->_UrlSafeIdentifier ??= str_replace(['https://standardebooks.org/ebooks/', '/'], ['', '_'], $this->Identifier);
 	}
 
 	protected function GetHeroImageUrl(): string{
@@ -547,7 +547,7 @@ final class Ebook{
 	}
 
 	protected function GetAuthorsUrl(): string{
-		return $this->_AuthorsUrl ??= preg_replace('|url:https://standardebooks.org/ebooks/([^/]+)/.*|ius', '/ebooks/\1', $this->Identifier);
+		return $this->_AuthorsUrl ??= preg_replace('|https://standardebooks.org/ebooks/([^/]+)/.*|ius', '/ebooks/\1', $this->Identifier);
 	}
 
 	protected function GetAuthorsString(): string{
@@ -1028,19 +1028,19 @@ final class Ebook{
 	 * Examples:
 	 *
 	 * 	$urlName = 'samuel-butler'
-	 * 	$identifier = 'url:https://standardebooks.org/ebooks/samuel-butler-1612-1680/hudibras'
+	 * 	$identifier = 'https://standardebooks.org/ebooks/samuel-butler-1612-1680/hudibras'
 	 * 	returns: 'samuel-butler-1612-1680'
 	 *
 	 * 	$urlName = 'william-wordsworth'
-	 * 	$identifier = 'url:https://standardebooks.org/ebooks/william-wordsworth_samuel-taylor-coleridge/lyrical-ballads'
+	 * 	$identifier = 'https://standardebooks.org/ebooks/william-wordsworth_samuel-taylor-coleridge/lyrical-ballads'
 	 * 	returns: 'william-wordsworth'
 	 *
 	 * 	$urlName = 'aylmer-maude'
-	 * 	$identifier = 'url:https://standardebooks.org/ebooks/leo-tolstoy/the-power-of-darkness/louise-maude_aylmer-maude'
+	 * 	$identifier = 'https://standardebooks.org/ebooks/leo-tolstoy/the-power-of-darkness/louise-maude_aylmer-maude'
 	 * 	returns: 'aylmer-maude'
 	 *
 	 * 	$urlName = 'leonard-welsted' // Elided from the Identifier with et-al.
-	 * 	$identifier = 'url:https://standardebooks.org/ebooks/ovid/metamorphoses/john-dryden_joseph-addison_laurence-eusden_arthur-maynwaring_samuel-croxall_nahum-tate_william-stonestreet_thomas-vernon_john-gay_alexander-pope_stephen-harvey_william-congreve_et-al'
+	 * 	$identifier = 'https://standardebooks.org/ebooks/ovid/metamorphoses/john-dryden_joseph-addison_laurence-eusden_arthur-maynwaring_samuel-croxall_nahum-tate_william-stonestreet_thomas-vernon_john-gay_alexander-pope_stephen-harvey_william-congreve_et-al'
 	 * 	returns: 'leonard-welsted' // Returns original input when there is no match.
 	 *
 	 */

--- a/scripts/deploy-ebook-to-www
+++ b/scripts/deploy-ebook-to-www
@@ -186,7 +186,7 @@ do
 		continue
 	fi
 
-	urlSafeIdentifier=$(git show HEAD:src/epub/content.opf | grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+<\/dc:identifier>" | sed --regexp-extended "s/<[^>]+?>//g" | sed --regexp-extended "s|url:https://standardebooks.org/ebooks/||g" | sed --regexp-extended "s|/|_|g")
+	urlSafeIdentifier=$(git show HEAD:src/epub/content.opf | grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">https://standardebooks.org/ebooks/[^<]+<\/dc:identifier>" | sed --regexp-extended "s/<[^>]+?>//g" | sed --regexp-extended "s|https://standardebooks.org/ebooks/||g" | sed --regexp-extended "s|/|_|g")
 
 	if [ "${lastPushHash}" != "" ]; then
 		# We were passed the hash of the last push before this one.
@@ -213,7 +213,7 @@ do
 		fi
 	fi
 
-	webDir=$(git show HEAD:src/epub/content.opf | grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+<\/dc:identifier>" | sed --regexp-extended "s/<[^>]+?>//g" | sed --regexp-extended "s/^url:https:\/\/standardebooks.org\/ebooks\/?//")
+	webDir=$(git show HEAD:src/epub/content.opf | grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">https://standardebooks.org/ebooks/[^<]+<\/dc:identifier>" | sed --regexp-extended "s/<[^>]+?>//g" | sed --regexp-extended "s/^https:\/\/standardebooks.org\/ebooks\/?//")
 
 	if [ "${webDir}" = "" ]; then
 		die "Empty webdir!"
@@ -304,7 +304,7 @@ do
 		fi
 
 		# Get the book URL.
-		bookUrl=$(grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">.+?</dc:identifier>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/.*?url:https:\/\/standardebooks.org(.*?)<.*/\1/g")
+		bookUrl=$(grep --only-matching --extended-regexp "<dc:identifier id=\"uid\">.+?</dc:identifier>" "${workDir}"/src/epub/content.opf | sed --regexp-extended "s/.*?https:\/\/standardebooks.org(.*?)<.*/\1/g")
 
 		# Get the last commit date so that we can update the modified timestamp in deployed `content.opf`. `generate-feeds` uses this timestamp in its output.
 		modifiedDate=$(TZ=UTC git log --date=iso-strict-local -1 --pretty=tformat:"%cd" --abbrev-commit | sed "s/+00:00/Z/")

--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -245,9 +245,9 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 
 	# get the last segment of the dc:identifier from the metadata
 	properName="$(git -C "${repoName}" show HEAD:src/epub/content.opf |
-		grep -oE "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+</dc:identifier>" |
+		grep -oE "<dc:identifier id=\"uid\">https://standardebooks.org/ebooks/[^<]+</dc:identifier>" |
 		sed -E "s/<[^>]+?>//g" |
-		sed -E "s|url:https://standardebooks.org/ebooks/||g" |
+		sed -E "s|https://standardebooks.org/ebooks/||g" |
 		sed -E "s|/|_|g").git"
 	if [ "${bare}" = "" ]; then
 		properName="${properName%.git}"

--- a/www/artworks/index.php
+++ b/www/artworks/index.php
@@ -67,7 +67,7 @@ try{
 
 	if($queryEbookUrl !== null){
 		// We're being called from the `review` script, and we're only interested if the artwork exists for this URL.
-		$artworks[] = Db::Query('SELECT a.* from Artworks a inner join Ebooks e using (EbookId) where e.Identifier = ? and Status = ? limit 1', ['url:' . $queryEbookUrl, Enums\ArtworkStatusType::Approved], Artwork::class)[0] ?? throw new Exceptions\ArtworkNotFoundException();
+		$artworks[] = Db::Query('SELECT a.* from Artworks a inner join Ebooks e using (EbookId) where e.Identifier = ? and Status = ? limit 1', [$queryEbookUrl, Enums\ArtworkStatusType::Approved], Artwork::class)[0] ?? throw new Exceptions\ArtworkNotFoundException();
 		$totalArtworkCount = 1;
 	}
 	else{

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -119,7 +119,7 @@ try{
 			$newEbookUrl = HttpInput::Str(POST, 'artwork-ebook-url');
 			if(isset($newEbookUrl)){
 				try{
-					$newEbook = Ebook::GetByIdentifier('url:' . $newEbookUrl);
+					$newEbook = Ebook::GetByIdentifier($newEbookUrl);
 				}
 				catch(Exceptions\EbookNotFoundException){
 					throw new Exceptions\InvalidUrlException($newEbookUrl);

--- a/www/blog/public-domain-day-2025.php
+++ b/www/blog/public-domain-day-2025.php
@@ -2,26 +2,26 @@
 
 // Condense getting all `Ebook`s into one DB query, and sort them at the PHP level, instead of doing so many separate queries to get each `Ebook`.
 $identifiers = [
-	'url:https://standardebooks.org/ebooks/william-faulkner/the-sound-and-the-fury',
-	'url:https://standardebooks.org/ebooks/erich-maria-remarque/all-quiet-on-the-western-front/a-w-wheen',
-	'url:https://standardebooks.org/ebooks/ernest-hemingway/a-farewell-to-arms',
-	'url:https://standardebooks.org/ebooks/mahatma-gandhi/the-story-of-my-experiments-with-truth/mahadev-desai',
-	'url:https://standardebooks.org/ebooks/john-steinbeck/cup-of-gold',
-	'url:https://standardebooks.org/ebooks/dashiell-hammett/red-harvest',
-	'url:https://standardebooks.org/ebooks/sinclair-lewis/dodsworth',
-	'url:https://standardebooks.org/ebooks/oliver-la-farge/laughing-boy',
-	'url:https://standardebooks.org/ebooks/calvin-coolidge/the-autobiography-of-calvin-coolidge',
-	'url:https://standardebooks.org/ebooks/graham-greene/the-man-within',
-	'url:https://standardebooks.org/ebooks/edith-wharton/hudson-river-bracketed',
-	'url:https://standardebooks.org/ebooks/lloyd-c-douglas/magnificent-obsession',
-	'url:https://standardebooks.org/ebooks/j-b-priestley/the-good-companions',
-	'url:https://standardebooks.org/ebooks/thomas-wolfe/look-homeward-angel',
-	'url:https://standardebooks.org/ebooks/dashiell-hammett/the-dain-curse',
-	'url:https://standardebooks.org/ebooks/c-s-forester/brown-on-resolution',
-	'url:https://standardebooks.org/ebooks/agatha-christie/the-seven-dials-mystery',
-	'url:https://standardebooks.org/ebooks/john-buchan/the-courts-of-the-morning',
-	'url:https://standardebooks.org/ebooks/arthur-conan-doyle/the-maracot-deep',
-	'url:https://standardebooks.org/ebooks/josephine-tey/the-man-in-the-queue',
+	'https://standardebooks.org/ebooks/william-faulkner/the-sound-and-the-fury',
+	'https://standardebooks.org/ebooks/erich-maria-remarque/all-quiet-on-the-western-front/a-w-wheen',
+	'https://standardebooks.org/ebooks/ernest-hemingway/a-farewell-to-arms',
+	'https://standardebooks.org/ebooks/mahatma-gandhi/the-story-of-my-experiments-with-truth/mahadev-desai',
+	'https://standardebooks.org/ebooks/john-steinbeck/cup-of-gold',
+	'https://standardebooks.org/ebooks/dashiell-hammett/red-harvest',
+	'https://standardebooks.org/ebooks/sinclair-lewis/dodsworth',
+	'https://standardebooks.org/ebooks/oliver-la-farge/laughing-boy',
+	'https://standardebooks.org/ebooks/calvin-coolidge/the-autobiography-of-calvin-coolidge',
+	'https://standardebooks.org/ebooks/graham-greene/the-man-within',
+	'https://standardebooks.org/ebooks/edith-wharton/hudson-river-bracketed',
+	'https://standardebooks.org/ebooks/lloyd-c-douglas/magnificent-obsession',
+	'https://standardebooks.org/ebooks/j-b-priestley/the-good-companions',
+	'https://standardebooks.org/ebooks/thomas-wolfe/look-homeward-angel',
+	'https://standardebooks.org/ebooks/dashiell-hammett/the-dain-curse',
+	'https://standardebooks.org/ebooks/c-s-forester/brown-on-resolution',
+	'https://standardebooks.org/ebooks/agatha-christie/the-seven-dials-mystery',
+	'https://standardebooks.org/ebooks/john-buchan/the-courts-of-the-morning',
+	'https://standardebooks.org/ebooks/arthur-conan-doyle/the-maracot-deep',
+	'https://standardebooks.org/ebooks/josephine-tey/the-man-in-the-queue',
 ];
 
 // Get all `Ebook`s that are not placeholders. We may have some PD Day books in our placeholders list but we don't want to show them here!
@@ -33,64 +33,64 @@ foreach($ebooks as $ebook){
 	$description = '';
 
 	switch($ebook->Identifier){
-		case 'url:https://standardebooks.org/ebooks/william-faulkner/the-sound-and-the-fury':
+		case 'https://standardebooks.org/ebooks/william-faulkner/the-sound-and-the-fury':
 			$description = '<p>Faulkner’s widely-acclaimed masterpiece is well-known in America, as it’s taught in high schools across the country. In it we follow the Compson family, an aristocratic family in Mississippi, and their slow decline into poverty and ruin. What makes the novel so special—and what lends it its reputation as a challenging read—is its stream-of-consciousness style, in which Faulkner attempts to narrate the characters’ thoughts directly to the reader.</p><p><i>The Sound and the Fury</i> was an essential step in developing that modernist prose style, and is still considered to be one of the greatest works of American literature.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/erich-maria-remarque/all-quiet-on-the-western-front/a-w-wheen':
+		case 'https://standardebooks.org/ebooks/erich-maria-remarque/all-quiet-on-the-western-front/a-w-wheen':
 			$description = '<p>One of the greatest war novels to come from any conflict, Erich Maria Remarque’s grisly tale of the brutality and horror of the German trenches during the Great War was so powerful that it earned him nominations for the Nobel Prizes in <em>both</em> Literature and Peace, and was soon widely banned in a Europe that was preparing for a second cataclysmic conflict.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/ernest-hemingway/a-farewell-to-arms':
+		case 'https://standardebooks.org/ebooks/ernest-hemingway/a-farewell-to-arms':
 			$description = '<p>Called “the premier American war novel from World War I,” Hemingway’s semi-autobiographical story of an American ambulance driver serving in the Italian front, and a bright and cynical British nurse, cemented his reputation as one of the generation’s foremost literary figures. Unlike Remarque, whose <i>All Quiet on the Western Front</i> paints the war’s destruction in full color, Hemingway’s story is one of the mundanity of war—of the quotidian smallness that underpins even the most horrific of events.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/john-steinbeck/cup-of-gold':
+		case 'https://standardebooks.org/ebooks/john-steinbeck/cup-of-gold':
 			$description = '<p><i>Cup of Gold</i> is John Steinbeck’s first novel, the swashbuckling story of the real-life Captain Morgan, legendary pirate. Little of Morgan’s actual life is known, but Steinbeck fills in the blanks of this rich historical fiction with lush portraits of Caribbean ports and flourishes of magical realism.</p><p>While one might expect a rollicking tale of adventure, the novel is actually a deep meditation on the pursuit of—and inability to find—true happiness, and its skillful craft deftly foreshadows Steinbeck’s later ascension to literary titanhood.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/dashiell-hammett/red-harvest':
+		case 'https://standardebooks.org/ebooks/dashiell-hammett/red-harvest':
 			$description = '<p><i>Red Harvest</i> is Dashiell Hammett’s first full-length novel to feature the <a href="/collections/continental-op">Continental Op</a>, the nameless, hard-drinking, cynical private eye that single-handedly created the archetype of the hard-boiled detective. The novel is a fast-paced, tightly-written murder thriller that simultaneously touches all the bases of, and <em>defines</em>, the classic noir style that was much-imitated, and later much-spoofed, in the following century.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/sinclair-lewis/dodsworth':
+		case 'https://standardebooks.org/ebooks/sinclair-lewis/dodsworth':
 			$description = '<p>Samuel Dodsworth is a successful automobile executive who decides to retire early. His younger wife Fran wants to tour Europe, so the two embark on a trip. But soon after they arrive, Fran becomes enchanted by the whirlwind of culture and old-world society, while Samuel, a mild-mannered, down-to-earth Midwesterner, yearns to escape the pretentiousness and return to the quiet stability of home. The novel explores the slow breakdown of their marriage while deftly satirizing American middle-class mores and the wide gulf between them and European culture.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/oliver-la-farge/laughing-boy':
+		case 'https://standardebooks.org/ebooks/oliver-la-farge/laughing-boy':
 			$description = '<p><i>Laughing Boy</i>, the winner of the 1930 <a href="/collections/pulitzer-prize-for-fiction-winners">Pulitzer Prize for Fiction</a>, is the story of the titular main character, a young Navajo man living in the American Southwest around the turn of the 20th century. He meets the fiery young Slim Girl at a tribal meet, but her reputation precedes her, and the tribe disapproves of their union. Ignoring the advice of the tribe, the two start a life together as they try to keep ancient traditions alive in the face of the rapidly-encroaching modernization of the American Southwest.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/graham-greene/the-man-within':
+		case 'https://standardebooks.org/ebooks/graham-greene/the-man-within':
 			$description = '<p><i>The Man Within</i> is acclaimed novelist Graham Greene’s first novel. Set against the backdrop of the English countryside, the novel explores themes of guilt, redemption, the nature of courage and cowardice, and the complex relationship between one’s inner beliefs and outward actions.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/calvin-coolidge/the-autobiography-of-calvin-coolidge':
+		case 'https://standardebooks.org/ebooks/calvin-coolidge/the-autobiography-of-calvin-coolidge':
 			$description = '<p>Calvin Coolidge was the 30th president of the United States, entering the office as vice president when president Warren G. Harding suddenly passed, and winning a reelection term. Even though he was hugely popular, he declined running for a second full term, opting to retire instead. In this autobiography—which is as brief as “Silent Cal’s” legend suggests it might be—we follow the former president from his idyllic boyhood in Vermont, to a career in the law, to the governorship of Massachusetts, to the presidency and beyond.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/lloyd-c-douglas/magnificent-obsession':
+		case 'https://standardebooks.org/ebooks/lloyd-c-douglas/magnificent-obsession':
 			$description = '<p>Robert Merrick, a young man from a wealthy family, accidentally causes the death of an esteemed neurosurgeon. Wracked by guilt, Robert decides to devote his own life to improving the life of others.</p><p><i>Magnificent Obsession</i> was a hugely popular work in its time, inspiring a blockbuster 1935 film of the same name.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/josephine-tey/the-man-in-the-queue':
+		case 'https://standardebooks.org/ebooks/josephine-tey/the-man-in-the-queue':
 			$description = '<p>Standing in line in a long queue for a show at a theater, a young man is stabbed in the back. <a href="/collections/inspector-grant">Inspector Alan Grant</a> of the Metropolitan Police is soon on the case, though he finds it deeply puzzling—not least because the identity of the victim is itself a mystery.</p><p><i>The Man in the Queue</i> was the first in a series of hugely successful detective novels by Josephine Tey.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/john-buchan/the-courts-of-the-morning':
+		case 'https://standardebooks.org/ebooks/john-buchan/the-courts-of-the-morning':
 			$description = '<p><i>The Courts of the Morning</i> opens with <a href="/collections/richard-hannay">Major-General Richard Hannay</a> being approached by American diplomats regarding the disappearance of a wealthy industrialist. He in turn seeks the help of his friend Sandy Arbuthnot—but Arbuthnot himself quickly goes missing. We soon head to the South American country of Olifa, where a powerful head of a mining company is gradually enslaving the populace. It seems that only guerrilla warfare will save the country from rule under a ruthless tyrant.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/j-b-priestley/the-good-companions':
+		case 'https://standardebooks.org/ebooks/j-b-priestley/the-good-companions':
 			$description = '<p>The recipient of the <a href="/collections/james-tait-black-memorial-fiction-prize-winners">James Tait Black Memorial Fiction Prize</a>, <i>The Good Companions</i> was a blockbuster novel that made J. B. Priestley’s reputation. In it we follow three protagonists from different walks of life who, looking for a change of pace, strike out from home. They eventually cross paths with each other and with a group of “concert players,” a type of traveling vaudeville troupe common in the day. They decide to join forces and form the “Good Companions,” a musical act that takes them on a series of cozy adventures.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/dashiell-hammett/the-dain-curse':
+		case 'https://standardebooks.org/ebooks/dashiell-hammett/the-dain-curse':
 			$description = '<p>In <i>The Dain Curse</i>, the second <a href="/collections/continental-op">Continental Op</a> novel, the legendary but nameless hard-drinking and quick-shooting detective is sent to investigate the theft of diamonds from a San Francisco family. The fast-paced noir thriller quickly veers from car chases to cultists to the supernatural, but the unflappable Continental Op is relentless in his pursuit of truth.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/c-s-forester/brown-on-resolution':
+		case 'https://standardebooks.org/ebooks/c-s-forester/brown-on-resolution':
 			$description = '<p>While on operations in the Pacific during the first World War, the sailor Albert Brown’s ship is sunk—but he survives, and is taken on board the German cruiser that sank them. It too has suffered damage, and heads to some nearby islands for repairs. In this unlikely and hostile setting, Brown, alone, pits himself against the German ship and its crew, seeking to delay its progress while British naval reinforcements rush to his rescue.</p><p>Forester’s careful historical research adds an unimpeachable air of verisimilitude to the novel, and indeed, the plot is loosely based on real events.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/arthur-conan-doyle/the-maracot-deep':
+		case 'https://standardebooks.org/ebooks/arthur-conan-doyle/the-maracot-deep':
 			$description = '<p>While investigating the deepest part of the Atlantic Ocean, a team led by Dr. Maracot is cut off from their ship and hurled to the bottom of the ocean. There, they find themselves in the remnants of the ancient civilization of Atlantis.</p><p>Though Doyle is most famous for his <a href="/collections/sherlock-holmes">Sherlock Holmes</a> stories, in which a brilliant logician uses reason and deduction to solve crime, in later years he became deeply spiritual. This novel, written just a year before his death, combines his interest in science and reason with his new spiritual outlook.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/edith-wharton/hudson-river-bracketed':
+		case 'https://standardebooks.org/ebooks/edith-wharton/hudson-river-bracketed':
 			$description = '<p>Vance Weston is a young Midwestern man looking to make his way in the world of literature. He gets his chance when he visits some relatives in New York, caretakers of a house in the titular Hudson River Bracketed style.</p><p>Weston is a boy of little means; perhaps it’s this vast gulf between the character’s life and Edith Wharton’s own life that allowed her to feel more free to write in many semi-autobiographical details. In any case, she considered <i>Hudson River Bracketed</i> to be her finest novel, and went so far as to write a sequel in 1932.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/mahatma-gandhi/the-story-of-my-experiments-with-truth/mahadev-desai':
+		case 'https://standardebooks.org/ebooks/mahatma-gandhi/the-story-of-my-experiments-with-truth/mahadev-desai':
 			$description = '<p>Mahatma Gandhi, father of the nation to post-colonial India, writes the story of his early life through 1921. He covers his childhood and his parents, his travels and his experiences with prejudice, how his interest in political activity and nonviolence developed throughout the years, and more. Despite this detailed treatment of his life, Gandhi asserts in the introduction that his purpose was not to write a “real autobiography,” but rather to “tell the story of my experiments with truth, and as my life consist of nothing but experiments.”</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/thomas-wolfe/look-homeward-angel';
+		case 'https://standardebooks.org/ebooks/thomas-wolfe/look-homeward-angel';
 			$description = '<p><i>Look Homeward, Angel</i> is Thomas Wolfe’s first novel, and the one on which his considerable fame as a master of the American autobiographical novel rests. The book covers the youth of Eugene Grant, a young man living in North Carolina, and widely considered to be a direct stand-in for Wolfe himself. It was a commercial and critical success, securing Wolfe’s reputation as one of the most important writers in the Southern Renaissance.</p>';
 			break;
-		case 'url:https://standardebooks.org/ebooks/agatha-christie/the-seven-dials-mystery';
+		case 'https://standardebooks.org/ebooks/agatha-christie/the-seven-dials-mystery';
 			$description = '<p><i>The Seven Dials Mystery</i> is the second book to feature <a href="/collections/superintendent-battle">Superintendent Battle</a> and the grand country estate of <a href="/ebooks/agatha-christie/the-secret-of-chimneys">Chimneys</a>. Chimneys is again the setting for a houseparty for a group of guests. One of them has a habit of oversleeping, and as a joke the other guests place eight alarm clocks near his bed to make sure he wakes up on time. Naturally, the next morning he’s discovered murdered in his bed—and Bundle, the bright daughter of the lord of Chimneys, takes up the case.</p>';
 			break;
 	}


### PR DESCRIPTION
Addresses https://github.com/standardebooks/tools/issues/831

Now that Identifier and FullUrl are identical we can remove one of them from Ebook.php, but that might be confusing for the different consumers. (e.g. ones that are web-first (rss/web) vs ones that are epub-first (database/opds?)).

I think a database command is required to remove `url:` from `Identifier` column.