### PR TITLE
Remove the <div> around ebook images

### DIFF
--- a/www/blog/public-domain-day-2025.php
+++ b/www/blog/public-domain-day-2025.php
@@ -131,11 +131,9 @@ ksort($ebooksWithDescriptions);
 			<ul class="public-domain-day">
 				<? foreach($ebooksWithDescriptions as $ebookGroup){ ?>
 					<li>
-						<div>
-							<a href="<?= $ebookGroup['ebook']->Url ?>">
-								<?= Template::RealisticEbook(ebook: $ebookGroup['ebook']) ?>
-							</a>
-						</div>
+						<a href="<?= $ebookGroup['ebook']->Url ?>">
+							<?= Template::RealisticEbook(ebook: $ebookGroup['ebook']) ?>
+						</a>
 						<div>
 							<h2>
 								<a href="<?= $ebookGroup['ebook']->Url ?>"><?= Formatter::EscapeHtml($ebookGroup['ebook']->Title) ?></a>

--- a/www/css/public-domain-day.css
+++ b/www/css/public-domain-day.css
@@ -7,11 +7,11 @@
 	margin-top: 6rem;
 }
 
-.public-domain-day div + div{
+.public-domain-day a + div{
 	margin-left: 1rem;
 }
 
-.public-domain-day div + div > p:last-child{
+.public-domain-day a + div > p:last-child{
 	text-align: right;
 	font-style: italic;
 }
@@ -59,11 +59,11 @@ figure.realistic-ebook.xxlarge{
 }
 
 @media(max-width: 1000px){
-	.public-domain-day div + div{
+	.public-domain-day a + div{
 		margin-left: 0;
 	}
 
-	.public-domain-day div > a{
+	.public-domain-day li > a{
 		width: 7rem;
 	}
 
@@ -81,7 +81,7 @@ figure.realistic-ebook.xxlarge{
 		text-align: center;
 	}
 
-	.public-domain-day div > a{
+	.public-domain-day li > a{
 		margin: auto;
 		display: block;
 		height: 15rem;


### PR DESCRIPTION
I thought maybe simplifying the DOM would help, and removing this `<div>` seems to prevent the crash reported in #510.

It's not a satisfying solution, so I can look for a different approach if you prefer. 