### PR TITLE
Update sync-ebooks

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -245,9 +245,9 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 
 	# get the last segment of the dc:identifier from the metadata
 	properName="$(git -C "${repoName}" show HEAD:src/epub/content.opf |
-		grep -oE "<dc:identifier id=\"uid\">url:https://standardebooks.org/ebooks/[^<]+</dc:identifier>" |
+		grep -oE "<dc:identifier id=\"uid\">https://standardebooks.org/ebooks/[^<]+</dc:identifier>" |
 		sed -E "s/<[^>]+?>//g" |
-		sed -E "s|url:https://standardebooks.org/ebooks/||g" |
+		sed -E "s|https://standardebooks.org/ebooks/||g" |
 		sed -E "s|/|_|g").git"
 	if [ "${bare}" = "" ]; then
 		properName="${properName%.git}"

--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -253,8 +253,9 @@ printf "%s\n" "${repoUrls}" | while IFS= read -r repoUrl; do
 		properName="${properName%.git}"
 	fi
 
-	# if for some reason the repository name isn't the same as the identifier (they are identical
-	# 99% of the time), rename the directory to be the identifier name; not sure why this is done, either
+	# if the repository name isn't the same as the identifier (GitHub has a size limitation on
+	# the length of a repo name; works with a lot of translators can exceed it), rename the 
+	# directory to be the identifier name
 	if [ "${repoName}" != "${properName}" ]; then
 		if [ -d "${properName}" ]; then
 			if [ "${verbosity}" -gt 0 ]; then


### PR DESCRIPTION
With the change to the URL scheme, i.e. eliminating the leading "url:", `sync-ebooks` needs a corresponding change, as it looks for URL's in the metadata at one point.

Also, when I originally added the comment to the code for the renaming of the repo to the identifier, I didn't know what was happening or why, and said that. I know both now, so this also updates the comment accordingly.

I also have two local changes that I want to see if you'd be interested in.
The first one adds a `--new-only` option, like the current `--update-only`, and does what you would expect. I often want to get the new books, but don't want to take the time at that moment to update the entire corpus. (This happens more often now that the corpus has gotten so large.)

The second one adds a `--start-letter` option, again as a result of the size of the corpus. If something happens during the update that causes it to die, e.g. forgotten local changes that shouldn't be there, a network glitch, whatever, having to restart from the beginning is a pain and waste of time. This lets me specify a starting letter, so I can re-start at P, or wherever, and not have to wait through the hundreds of books prior being processed again to no effect.