### PR TITLE
Add Popularity sort type

### DIFF
--- a/config/sql/se/Ebooks.sql
+++ b/config/sql/se/Ebooks.sql
@@ -36,5 +36,6 @@ CREATE TABLE IF NOT EXISTS `Ebooks` (
   FULLTEXT `idxSearchTitle` (`Title`),
   FULLTEXT `idxSearchAuthors` (`IndexableAuthors`),
   FULLTEXT `idxSearchCollections` (`IndexableCollections`),
-  FULLTEXT `idxSearchCombined` (`IndexableText`, `Title`, `IndexableAuthors`, `IndexableCollections`)
+  FULLTEXT `idxSearchCombined` (`IndexableText`, `Title`, `IndexableAuthors`, `IndexableCollections`),
+  KEY `idxPopularity` (`DownloadsPast30Days` DESC, `EbookCreated` DESC)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lib/Ebook.php
+++ b/lib/Ebook.php
@@ -2389,13 +2389,19 @@ final class Ebook{
 		if($sort == Enums\EbookSortType::AuthorAlpha){
 			$joinContributors = 'inner join Contributors con using (EbookId)';
 			$whereCondition .= ' and con.MarcRole = "aut"';
-			$orderBy = 'e.WwwFilesystemPath is null, con.SortName, e.EbookCreated desc'; // Put placeholders at the end
+			$orderBy = 'e.WwwFilesystemPath is null, con.SortName, e.EbookCreated desc'; // Put placeholders at the end.
 		}
 		elseif($sort == Enums\EbookSortType::ReadingEase){
 			$orderBy = 'e.ReadingEase desc';
 		}
 		elseif($sort == Enums\EbookSortType::Length){
-			$orderBy = 'e.WwwFilesystemPath is null, e.WordCount'; // Put placeholders at the end
+			$orderBy = 'e.WwwFilesystemPath is null, e.WordCount'; // Put placeholders at the end.
+		}
+		elseif($sort == Enums\EbookSortType::Popularity){
+			// Searches with a keyword `query` present sort placeholdrs at the end because their
+			// `DownloadsPast30Days` count is zero and their `EbookCreated` date is `NULL`.
+			// Searches without a keyword `query` filter out placeholders in the `WHERE` clause.
+			$orderBy = 'e.DownloadsPast30Days desc, e.EbookCreated desc';
 		}
 
 		if(sizeof($tags) > 0 && !in_array('all', $tags)){ // 0 tags means "all ebooks"

--- a/lib/Enums/EbookSortType.php
+++ b/lib/Enums/EbookSortType.php
@@ -7,5 +7,6 @@ enum EbookSortType: string{
 	case ReadingEase = 'reading-ease';
 	case Length = 'length';
 	case Relevance = 'relevance';
+	case Popularity = 'popularity';
 	case Default = 'default'; // Interpreted as `Relevance` if a query is present, `Newest` if not.
 }

--- a/templates/SearchForm.php
+++ b/templates/SearchForm.php
@@ -34,6 +34,7 @@ $isAllSelected = sizeof($tags) == 0 || in_array('all', $tags);
 				<option value="<?= Enums\EbookSortType::AuthorAlpha->value ?>"<? if($sort == Enums\EbookSortType::AuthorAlpha){ ?> selected="selected"<? } ?>>Author name (a &#x2192; z)</option>
 				<option value="<?= Enums\EbookSortType::ReadingEase->value ?>"<? if($sort == Enums\EbookSortType::ReadingEase){ ?> selected="selected"<? } ?>>Reading ease (easy &#x2192; hard)</option>
 				<option value="<?= Enums\EbookSortType::Length->value ?>"<? if($sort == Enums\EbookSortType::Length){ ?> selected="selected"<? } ?>>Length (short &#x2192; long)</option>
+				<option value="<?= Enums\EbookSortType::Popularity->value ?>"<? if($sort == Enums\EbookSortType::Popularity){ ?> selected="selected"<? } ?>>Popularity</option>
 			</select>
 		</span>
 	</label>


### PR DESCRIPTION
Here's the fun part of #298!

It's been more than 30 days since #508, so the production DB should have a good set of download data. It's also fine to wait and inspect the download data before launching this. It works on my test database, but I don't have very much download data.

Existing DBs will need this index:


```sql
ALTER TABLE Ebooks ADD KEY `idxPopularity` (`DownloadsPast30Days` DESC, `EbookCreated` DESC);
```

The explain plan looks fine:

```sql
MariaDB [se]> explain SELECT distinct e.* from Ebooks e where e.WwwFilesystemPath is not null order by e.DownloadsPast30Days desc, e.EbookCreated desc limit 12 offset 0;
+------+-------------+-------+-------+---------------+---------------+---------+------+------+-------------+
| id   | select_type | table | type  | possible_keys | key           | key_len | ref  | rows | Extra       |
+------+-------------+-------+-------+---------------+---------------+---------+------+------+-------------+
|    1 | SIMPLE      | e     | index | NULL          | idxPopularity | 10      | NULL | 12   | Using where |
+------+-------------+-------+-------+---------------+---------------+---------+------+------+-------------+

```

I'm also open to suggestions on naming or anything else.