### PR TITLE
Move `.honeypot` rule to `ereader.css`

### DIFF
--- a/www/css/core.css
+++ b/www/css/core.css
@@ -614,15 +614,6 @@ main.front-page > section > section > h3{
 	hyphens: none;
 }
 
-.honeypot{
-	/* Hide from clients who don't support the `@hidden` attribute, like older Kindle browsers. */
-	/* Select using a class for older renderers like Kindle in-browser renderer. */
-	display: none;
-	position: absolute;
-	left: -9999rem;
-	font-size: 0;
-}
-
 main.center h1{
 	margin-top: 4rem;
 	border: none;

--- a/www/css/ereader.css
+++ b/www/css/ereader.css
@@ -222,3 +222,12 @@ main.ebooks nav ol{
 main.ebooks nav ol li{
 	padding: 1rem;
 }
+
+.honeypot{
+	/* Hide from clients who don't support the `@hidden` attribute, like older Kindle browsers. */
+	/* Select using a class for older renderers like Kindle in-browser renderer. */
+	display: none;
+	position: absolute;
+	left: -9999rem;
+	font-size: 0;
+}


### PR DESCRIPTION
Kindle and Kobo browsers don't request `core.css`

Before:

<img width="740" height="757" alt="Screenshot_2025-08-29_15-50-16" src="https://github.com/user-attachments/assets/e1b55bd2-f831-4244-b4cf-fdc6b9c3e5a6" />

After:

<img width="744" height="763" alt="Screenshot_2025-08-29_15-51-03" src="https://github.com/user-attachments/assets/f3e0c9dd-35f9-44b2-9925-47cd4e8ac9ff" />
