### PR TITLE
add www to fracturedatlas.org url

### DIFF
--- a/www/help/donating-via-a-donor-advised-fund.php
+++ b/www/help/donating-via-a-donor-advised-fund.php
@@ -5,7 +5,7 @@
 		<p>
 			<i>(You can read more about donating via a Donor-Advised Fund at <a href="https://fracturedatlas.zendesk.com/hc/en-us/articles/115001326294-Donor-Advised-Donations">this Fractured Atlas help desk article</a>.)</i>
 		</p>
-		<p>Standard Ebooks can accept donations from Donor-Advised Funds via <a href="https://fracturedatlas.org">Fractured Atlas</a>, our 501(c)(3) fiscal sponsor.</p>
+		<p>Standard Ebooks can accept donations from Donor-Advised Funds via <a href="https://www.fracturedatlas.org">Fractured Atlas</a>, our 501(c)(3) fiscal sponsor.</p>
 		<p>Typically a Donor-Advised Fund has a web portal allowing you to select the recipient of your donation.</p>
 		<p>All donations must be made out to Fractured Atlas, with a note included saying that the donation is being made for the purposes of Standard Ebooks. Fractured Atlas will receive and process your donation, and then make it available to us. This process can take several weeks.</p>
 		<p>We love to reach out to thank our supporters! Please make sure to include an email address with your donation if you’d like us to get in touch with you.</p>


### PR DESCRIPTION
www is needed to avoid an ssl error in the browser.

arguably fracturedatlas should have a cert that covers this, but it appears that it doesn't.