### PR TITLE
Set CURLOPT_FOLLOWLOCATION to true

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -37,6 +37,7 @@ class CurlRequest{
 		curl_setopt($curl, CURLOPT_FORBID_REUSE, true);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method->value);
+		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
 		if($method != Enums\HttpMethod::Get && $httpData != ''){
 			curl_setopt($curl, CURLOPT_POSTFIELDS, $httpData);


### PR DESCRIPTION
Resolving many canonical museum URLs require following 301 redirects, e.g., https://www.rijksmuseum.nl/en/collection/SK-C-374, so I need to set this option for my current project.

I considered adding a `bool $followLocation = false` method parameter like this:

```php
public static function Execute(Enums\HttpMethod $method, string $url, array|string|stdClass $data = [], array $headers = [], bool $followLocation = false): CurlStringResponse{
    [...]
}
```

Let me know if you'd prefer that approach. I thought it was fine to just set `CURLOPT_FOLLOWLOCATION` for all requests because none of the other current uses care about 301 responses, and I thought another method parameter was a bit excessive.