### PR TITLE
Add a "Review cover art" step to the review guide

### DIFF
--- a/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
+++ b/www/contribute/how-tos/how-to-review-an-ebook-production-for-publication.php
@@ -179,6 +179,10 @@
 				</ul>
 			</li>
 			<li>
+				<h2>Review cover art</h2>
+				<p>Open <code>./images/cover.jpg</code> in your image editor of choice and examine it to make sure it is cropped correctly (<abbr>i.e.</abbr> there is no whitespace on the margins).</p>
+			</li>
+			<li>
 				<h2>Lint again</h2>
 				<p>Run a final <code class="bash"><b>se</b> lint <u>.</u></code> check, and ensure it is silent. If any warnings and errors are produced, they must be noted and addressed.</p>
 			</li>


### PR DESCRIPTION
It occurred to me that we should be checking the cover art crop as part of our review, but we don't have it as a formal part of the process. I think there have been several cases now where the producer cropped the image incorrectly and this made it to production.