### PR TITLE
Add paragraph to Step by Step clarifying lint error commits

### DIFF
--- a/www/contribute/producing-an-ebook-step-by-step.php
+++ b/www/contribute/producing-an-ebook-step-by-step.php
@@ -592,6 +592,7 @@ proceed to seal up my confession, I bring the life of that unhappy Henry Jekyll 
 				<p>Now, run <code class="bash"><b>se</b> lint</code>. If your ebook has any problems, you’ll see some output listing them. We’re expecting some errors, because we haven’t added a cover or completed the colophon or metadata. You can ignore those errors for now, because we’ll fix them in a later step. But, you <em>do</em> want to correct any fixable errors related to your previous work.</p>
 				<code class="terminal"><span><b>se</b> lint <u>.</u></span></code>
 				<p>If there are no errors, <code class="bash"><b>se</b> lint</code> will complete silently—but again, at this stage we’re expecting to see some errors because our ebook isn’t done yet.</p>
+				<p>When correcting the errors, be sure to keep each commit to a single unit of work, and to signify what is being <em>changed</em> in the commit message, not what prompted the change. Lint can identify a wide variety of issues, and they should not all be lumped together in the same commit, nor should the commit message be something like “Fix lint errors.” Instead, “Fix transcription typos identified by lint” or “Correct header semantics identified by lint,” and so forth, would be more appropriate. 
 			</li>
 			<li>
 				<h2 id="proofread">Build and proofread, proofread, proofread!</h2>


### PR DESCRIPTION
One of the things I and the rest of the reviewers (judging from comments over time) regularly run into is someone correcting a bunch of disparate lint errors in a single commit with a message like "Fix lint errors." Sometimes it's more than one commit with that kind of message. Either way, they seem to forget the "one unit of work" and "good commit message"* principles when they get to lint. On the relatively rare occasions when lint identifies issues that end up being a combination of editorial and non-editorial, they don't remember that, either. Yes, I agree, they should remember all of those things, but they don't. :) They're new to our process, and many of them are (relatively) new to git, and even the ones that aren't are new to how _we_ handle git. I didn't get it when I started, either, probably for the first half-dozen books or so (although we are much further along in our documentation and help than when I started). Still, this is a common problem, so maybe some additional text at the point of pain will help.

This adds a paragraph to the lint step in the Step by Step to clarify how they should handle committing fixes to what lint identifies. You're always better at wordsmithing these kinds of things than the rest of us, so you can change it after commit, or if your changes are minor and you can tell me I'll be glad to update it. But based on how often this happens (almost every first production I review), I think _something_ would help.

*I don't see that we address what a good commit message looks like. Should we, at least high-level, e.g. "tell what/why rather than how" or something similar?