### PR TITLE
Fix alphabet (duplicate letter o)

### DIFF
--- a/scripts/sync-ebooks
+++ b/scripts/sync-ebooks
@@ -88,7 +88,7 @@ if ! sed --version 2>/dev/null | head --lines 1 | grep --quiet 'GNU sed'; then
 	ExitWithError "GNU [command]sed[/] is required. On Mac, install the GNU version via Homebrew, MacPorts, etc. and make sure it's first in [parameter]\$PATH[/]."
 fi
 
-LETTERS="abcdefghijklmnopoqrstuvwxyz"
+LETTERS="abcdefghijklmnopqrstuvwxyz"
 verbosity=0
 newUpdate=""
 githubToken=""


### PR DESCRIPTION
The alphabet for the `--start-letter` option contained a superfluous `o`. As far as I followed the start-letter code path, it does not impact the correctness of the code. Still, it might hurt sometime in the future.