### PR TITLE
Fix missing space in description of books entering PD next year

### DIFF
--- a/lib/EbookPlaceholder.php
+++ b/lib/EbookPlaceholder.php
@@ -62,7 +62,7 @@ class EbookPlaceholder{
 					}
 					else{
 						$months = 13 - (int)(NOW->format('n'));
-						$this->_TimeTillIsPublicDomain = $months . Formatter::Pluralize($months, 'month');
+						$this->_TimeTillIsPublicDomain = $months . ' ' . Formatter::Pluralize($months, 'month');
 					}
 				}
 			}


### PR DESCRIPTION
Example: https://standardebooks.org/ebooks/carolyn-keene/the-secret-at-shadow-ranch

> This book was published in 1931, and will therefore enter the U.S. public domain in 6months on **January 1, 2027.**

This adds a space between "6" and "months".

Introduced in c46a34dc55c349502c36c6c4e3b24c9dbfd46cf9.